### PR TITLE
fix: check web camera availability. Closes #472

### DIFF
--- a/mobile/src/screens/profile/UploadArticleScreen.tsx
+++ b/mobile/src/screens/profile/UploadArticleScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   View, Text, StyleSheet, TouchableOpacity, SafeAreaView,
-  ScrollView, TextInput, ActivityIndicator, Image,
+  ScrollView, TextInput, ActivityIndicator, Image, Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
@@ -139,6 +139,34 @@ const UploadArticleScreen: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [categoryOpen, setCategoryOpen] = useState(false);
+  const [cameraAvailable, setCameraAvailable] = useState<boolean | null>(null);
+  
+  const [showCameraModal, setShowCameraModal] = useState(false);
+  const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
+  const [capturedPhoto, setCapturedPhoto] = useState<string | null>(null);
+
+  useEffect(() => {
+    const checkCameraAvailability = async () => {
+      try {
+        if (Platform.OS === 'web') {
+          if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            const hasCamera = devices.some(device => device.kind === 'videoinput');
+            setCameraAvailable(hasCamera);
+          } else {
+            setCameraAvailable(false);
+          }
+        } else {
+          const { status } = await ImagePicker.requestCameraPermissionsAsync();
+          setCameraAvailable(status === 'granted');
+        }
+      } catch {
+        setCameraAvailable(false);
+      }
+    };
+    
+    checkCameraAvailability();
+  }, []);
 
   useEffect(() => {
     const loadCategories = async () => {
@@ -175,20 +203,68 @@ const UploadArticleScreen: React.FC = () => {
 
   const takePicture = async () => {
     try {
-      const perm = await ImagePicker.requestCameraPermissionsAsync();
-      if (!perm.granted) {
-        showNotification('Se requiere acceso a la cámara para tomar fotos', 'error');
-        return;
-      }
-      const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, aspect: [4, 3], quality: 0.8 });
-      if (!result.canceled && result.assets?.length > 0) {
-        const asset = result.assets[0];
-        setSelectedImage({ uri: asset.uri, name: `photo_${Date.now()}.jpg` });
-        clearError('image');
+      if (Platform.OS === 'web') {
+
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        setCameraStream(stream);
+        setShowCameraModal(true);
+      } else {
+
+        const perm = await ImagePicker.requestCameraPermissionsAsync();
+        if (!perm.granted) {
+          showNotification('Se requiere acceso a la cámara para tomar fotos', 'error');
+          return;
+        }
+        const result = await ImagePicker.launchCameraAsync({ allowsEditing: true, aspect: [4, 3], quality: 0.8 });
+        if (!result.canceled && result.assets?.length > 0) {
+          const asset = result.assets[0];
+          setSelectedImage({ uri: asset.uri, name: `photo_${Date.now()}.jpg` });
+          clearError('image');
+        }
       }
     } catch {
-      showNotification('No se pudo tomar la foto', 'error');
+      showNotification('No se pudo acceder a la cámara', 'error');
     }
+  };
+
+  const capturePhoto = () => {
+    const videoElement = document.querySelector('#camera-video') as HTMLVideoElement;
+    if (videoElement) {
+      const canvas = document.createElement('canvas');
+      canvas.width = videoElement.videoWidth;
+      canvas.height = videoElement.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.drawImage(videoElement, 0, 0);
+        canvas.toBlob((blob) => {
+          if (blob) {
+            const uri = URL.createObjectURL(blob);
+            setCapturedPhoto(uri);
+          }
+        }, 'image/jpeg', 0.8);
+      }
+    }
+  };
+
+  const confirmPhoto = () => {
+    if (capturedPhoto) {
+      setSelectedImage({ uri: capturedPhoto, name: `photo_${Date.now()}.jpg` });
+      clearError('image');
+      closeCameraModal();
+    }
+  };
+
+  const discardPhoto = () => {
+    setCapturedPhoto(null);
+  };
+
+  const closeCameraModal = () => {
+    if (cameraStream) {
+      cameraStream.getTracks().forEach(track => track.stop());
+    }
+    setCameraStream(null);
+    setCapturedPhoto(null);
+    setShowCameraModal(false);
   };
 
   const clearError = (key: string) => setErrors((prev) => ({ ...prev, [key]: '' }));
@@ -502,15 +578,17 @@ const UploadArticleScreen: React.FC = () => {
                   <Text style={styles.placeholderText}>Sube una foto de tu artículo</Text>
                 </View>
               )}
-              <View style={styles.buttonRow}>
-                <TouchableOpacity style={styles.imageButton} onPress={pickImage}>
+              <View style={[styles.buttonRow, !cameraAvailable && styles.buttonRowWeb]}>
+                <TouchableOpacity style={[styles.imageButton, !cameraAvailable && styles.imageButtonWeb]} onPress={pickImage}>
                   <Ionicons name="images" size={20} color={Colors.primary} />
                   <Text style={styles.imageButtonText}>Galería</Text>
                 </TouchableOpacity>
-                <TouchableOpacity style={styles.imageButton} onPress={takePicture}>
-                  <Ionicons name="camera" size={20} color={Colors.primary} />
-                  <Text style={styles.imageButtonText}>Cámara</Text>
-                </TouchableOpacity>
+                {cameraAvailable && (
+                  <TouchableOpacity style={styles.imageButton} onPress={takePicture}>
+                    <Ionicons name="camera" size={20} color={Colors.primary} />
+                    <Text style={styles.imageButtonText}>Cámara</Text>
+                  </TouchableOpacity>
+                )}
               </View>
             </View>
 
@@ -580,6 +658,57 @@ const UploadArticleScreen: React.FC = () => {
 
           <View style={{ height: Spacing.xxl }} />
         </ScrollView>
+
+        {showCameraModal && Platform.OS === 'web' && (
+          <View style={styles.cameraModalOverlay}>
+            <View style={styles.cameraModalContent}>
+              {!capturedPhoto ? (
+                <>
+                  <Text style={styles.cameraModalTitle}>Cámara</Text>
+                  <video
+                    id="camera-video"
+                    style={styles.cameraVideo}
+                    autoPlay
+                    playsInline
+                    ref={(ref) => {
+                      if (ref && cameraStream) {
+                        ref.srcObject = cameraStream;
+                      }
+                    }}
+                  />
+                  <View style={styles.cameraButtonsRow}>
+                    <TouchableOpacity style={[styles.cameraButton, styles.cameraButtonSecondary]} onPress={closeCameraModal}>
+                      <Ionicons name="close" size={24} color={Colors.error} />
+                      <Text style={[styles.cameraButtonText, { color: Colors.error }]}>Cerrar</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={[styles.cameraButton, styles.cameraButtonPrimary]} onPress={capturePhoto}>
+                      <Ionicons name="camera" size={24} color="white" />
+                      <Text style={[styles.cameraButtonText, { color: 'white' }]}>Capturar</Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              ) : (
+                <>
+                  <Text style={styles.cameraModalTitle}>Foto capturada</Text>
+                  <Image
+                    source={{ uri: capturedPhoto }}
+                    style={styles.capturedPhotoPreview}
+                  />
+                  <View style={styles.cameraButtonsRow}>
+                    <TouchableOpacity style={[styles.cameraButton, styles.cameraButtonSecondary]} onPress={discardPhoto}>
+                      <Ionicons name="trash" size={24} color={Colors.error} />
+                      <Text style={[styles.cameraButtonText, { color: Colors.error }]}>Descartar</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={[styles.cameraButton, styles.cameraButtonPrimary]} onPress={confirmPhoto}>
+                      <Ionicons name="checkmark" size={24} color="white" />
+                      <Text style={[styles.cameraButtonText, { color: 'white' }]}>Confirmar</Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              )}
+            </View>
+          </View>
+        )}
       </SafeAreaView>
     </PaperProvider>
   );
@@ -756,6 +885,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: Spacing.md,
   },
+  buttonRowWeb: {
+    gap: Spacing.md,
+  },
   imageButton: {
     flex: 1,
     flexDirection: 'row',
@@ -768,6 +900,9 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.border,
     borderWidth: 1,
     borderColor: Colors.primary,
+  },
+  imageButtonWeb: {
+    flex: 1,
   },
   imageButtonText: {
     color: Colors.primary,
@@ -811,6 +946,72 @@ const styles = StyleSheet.create({
   conditionChipTextActive: {
     color: Colors.primary,
     fontWeight: '700',
+  },
+
+  // ── Web Camera Modal ──────────────────────────────────────────────────────
+  cameraModalOverlay: {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 1000,
+  },
+  cameraModalContent: {
+    backgroundColor: Colors.backgroundWhite,
+    borderRadius: 16,
+    overflow: 'hidden',
+    width: '90%',
+    maxWidth: 600,
+    gap: Spacing.md,
+    padding: Spacing.lg,
+  },
+  cameraModalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.textPrimaryHome,
+    textAlign: 'center',
+  },
+  cameraVideo: {
+    width: '100%',
+    height: 400,
+    borderRadius: 8,
+    backgroundColor: Colors.backgroundWhite,
+    objectFit: 'contain' as const,
+  },
+  capturedPhotoPreview: {
+    width: '100%',
+    height: 400,
+    borderRadius: 8,
+    resizeMode: 'contain',
+  },
+  cameraButtonsRow: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+  },
+  cameraButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.md,
+    borderRadius: 8,
+  },
+  cameraButtonPrimary: {
+    backgroundColor: Colors.primary,
+  },
+  cameraButtonSecondary: {
+    backgroundColor: Colors.border,
+    borderWidth: 1,
+    borderColor: Colors.error,
+  },
+  cameraButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
 });
 


### PR DESCRIPTION
La cámara no se abría en dispositivos web, sino que abría el explorador de archivos. Tras probar en un dispositivo móvil y ver que el comportamiento sí que era el esperado, he implementado algunos cambios en UploadArticleScreen.tsx. Ahora diferencia el comportamiento entre web y móvil: en web implementa una modal con captura de foto mediante canvas, y en móvil usa ImagePicker (se mantiene como estaba). Además, verifica la disponibilidad de cámara antes de mostrar el botón de cámara.