### PR TITLE
fix: show owner commission promo badge

### DIFF
--- a/backend/src/main/java/com/example/demo/dto/UserArticle.java
+++ b/backend/src/main/java/com/example/demo/dto/UserArticle.java
@@ -8,5 +8,6 @@ public record UserArticle(
     String imageUrl,
     Double pricePerMonth,
     String status,         // Ejemplo: "AVAILABLE", "RENTED"
-    LocalDate rentedUntil  // Si status es RENTED, tendrá la fecha. Si no, será null.
+    LocalDate rentedUntil,  // Si status es RENTED, tendrá la fecha. Si no, será null.
+    String ownerCommissionPromoCode
 ) {}

--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -333,7 +333,8 @@ public class ArticleService {
                 article.getImageUrl(),
                 article.getPricePerMonth(),
                 finalStatus,
-                rentedUntil
+                rentedUntil,
+                article.getOwnerCommissionPromoCode()
         );
     }
 
@@ -449,7 +450,8 @@ public class ArticleService {
                 article.getImageUrl(),
                 article.getPricePerMonth(),
                 article.getStatus() != null ? article.getStatus().name() : "UNKNOWN",
-                rentedUntil
+                rentedUntil,
+                article.getOwnerCommissionPromoCode()
             );
         }).collect(Collectors.toList());
     }

--- a/backend/src/test/java/com/example/demo/article/ArticleControllerTest.java
+++ b/backend/src/test/java/com/example/demo/article/ArticleControllerTest.java
@@ -11,6 +11,7 @@ import com.example.demo.security.TokenBlacklistService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -23,10 +24,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -105,6 +108,33 @@ class ArticleControllerTest {
                 .content("{\"title\":\"t\",\"description\":\"d\",\"city\":\"c\",\"pricePerMonth\":10.0}"))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.title").value("t"));
+    }
+
+    @Test
+    void uploadArticle_withOwnerCommissionPromoCode_sendsFieldToServiceAndResponseIncludesIt() throws Exception {
+        Article saved = new Article();
+        saved.setId(10L);
+        saved.setTitle("Taladro");
+        saved.setDescription("d");
+        saved.setCity("c");
+        saved.setPricePerMonth(10.0);
+        saved.setStatus(ArticleStatus.AVAILABLE);
+        saved.setOwnerCommissionPromoCode("OWNER10");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+        when(articleService.save(any(Article.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/article/upload")
+                .param("ownerId", "1")
+                .param("categoryId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"Taladro\",\"description\":\"d\",\"city\":\"c\",\"pricePerMonth\":10.0,\"ownerCommissionPromoCode\":\"OWNER10\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.ownerCommissionPromoCode").value("OWNER10"));
+
+        ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+        verify(articleService).save(captor.capture());
+        assertThat(captor.getValue().getOwnerCommissionPromoCode()).isEqualTo("OWNER10");
     }
 
     @Test
@@ -197,6 +227,24 @@ class ArticleControllerTest {
         mockMvc.perform(get("/api/article/all"))
             .andExpect(status().isInternalServerError())
             .andExpect(content().string("DB error"));
+    }
+
+    @Test
+    void getArticleById_withOwnerCommissionPromoCode_returnsField() throws Exception {
+        Article articleWithOwnerPromo = new Article();
+        articleWithOwnerPromo.setId(1L);
+        articleWithOwnerPromo.setTitle("Taladro");
+        articleWithOwnerPromo.setDescription("d");
+        articleWithOwnerPromo.setCity("c");
+        articleWithOwnerPromo.setPricePerMonth(10.0);
+        articleWithOwnerPromo.setStatus(ArticleStatus.AVAILABLE);
+        articleWithOwnerPromo.setOwnerCommissionPromoCode("OWNER10");
+
+        when(articleService.findById(1L)).thenReturn(articleWithOwnerPromo);
+
+        mockMvc.perform(get("/api/article/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ownerCommissionPromoCode").value("OWNER10"));
     }
 
 
@@ -314,8 +362,8 @@ class ArticleControllerTest {
 
     @Test
     void getMyArticles_success() throws Exception {
-        UserArticle dto1 = new UserArticle(10L, "Taladro", "url1", 15.0, "AVAILABLE", null);
-        UserArticle dto2 = new UserArticle(11L, "Bicicleta", "url2", 30.0, "RENTED", LocalDate.of(2026, 12, 31));
+        UserArticle dto1 = new UserArticle(10L, "Taladro", "url1", 15.0, "AVAILABLE", null, null);
+        UserArticle dto2 = new UserArticle(11L, "Bicicleta", "url2", 30.0, "RENTED", LocalDate.of(2026, 12, 31), null);
 
         when(articleService.findArticlesByUserId(eq(1L), any(), any(), any(), any())).thenReturn(List.of(dto1, dto2));
 
@@ -329,6 +377,18 @@ class ArticleControllerTest {
             .andExpect(jsonPath("$[1].title").value("Bicicleta"))
             .andExpect(jsonPath("$[1].status").value("RENTED"))
             .andExpect(jsonPath("$[1].rentedUntil").value("2026-12-31"));
+    }
+
+    @Test
+    void getMyArticles_withOwnerCommissionPromoCode_returnsField() throws Exception {
+        UserArticle dto = new UserArticle(10L, "Taladro", "url1", 15.0, "AVAILABLE", null, "OWNER10");
+
+        when(articleService.findArticlesByUserId(eq(1L), any(), any(), any(), any())).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/article/my-articles/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].title").value("Taladro"))
+            .andExpect(jsonPath("$[0].ownerCommissionPromoCode").value("OWNER10"));
     }
 
     @Test
@@ -371,7 +431,7 @@ class ArticleControllerTest {
 
     @Test
     void getLatestArticlesByCategory_success() throws Exception {
-        UserArticle dto = new UserArticle(10L, "Taladro de prueba", "url_img", 15.0, "AVAILABLE", null);
+        UserArticle dto = new UserArticle(10L, "Taladro de prueba", "url_img", 15.0, "AVAILABLE", null, null);
 
         when(articleService.findLatestArticlesByCategory(1L)).thenReturn(List.of(dto));
 
@@ -386,7 +446,7 @@ class ArticleControllerTest {
     // Test filtros MyArticles
     @Test
     void getMyArticles_withAllFilters_success() throws Exception {
-        UserArticle dtoFiltered = new UserArticle(12L, "Taladro Nuevo", "url3", 25.0, "AVAILABLE", null);
+        UserArticle dtoFiltered = new UserArticle(12L, "Taladro Nuevo", "url3", 25.0, "AVAILABLE", null, null);
 
       
         when(articleService.findArticlesByUserId(eq(1L), eq(5L), eq("NEW"), eq(10.0), eq(50.0)))
@@ -406,7 +466,7 @@ class ArticleControllerTest {
 
     @Test
     void getMyArticles_withPartialFilters_success() throws Exception {
-        UserArticle dtoFiltered = new UserArticle(13L, "Bicicleta Barata", "url4", 15.0, "AVAILABLE", null);
+        UserArticle dtoFiltered = new UserArticle(13L, "Bicicleta Barata", "url4", 15.0, "AVAILABLE", null, null);
 
        
         when(articleService.findArticlesByUserId(eq(1L), isNull(), eq("USED"), isNull(), eq(20.0)))

--- a/backend/src/test/java/com/example/demo/article/ArticleIntegrationTest.java
+++ b/backend/src/test/java/com/example/demo/article/ArticleIntegrationTest.java
@@ -6,6 +6,7 @@ import com.example.demo.repository.CategoryRepository;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,7 @@ class ArticleIntegrationTest {
     @Autowired private UserRepository userRepository;
     @Autowired private CategoryRepository categoryRepository;
     @Autowired private ObjectMapper objectMapper;
+    @Autowired private EntityManager entityManager;
 
     @MockitoBean private AuthService authService;
 
@@ -462,6 +464,26 @@ class ArticleIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].title").value("Taladro"));
+    }
+
+    @Test
+    void testGetMyArticles_Integration_ReturnsPersistedOwnerCommissionPromoCode() throws Exception {
+        savedArticle.setOwnerCommissionPromoCode("OWNER10");
+        articleRepository.saveAndFlush(savedArticle);
+        entityManager.clear();
+
+        Article persisted = articleRepository.findById(savedArticle.getId()).orElseThrow();
+        assertThat(persisted.getOwnerCommissionPromoCode()).isEqualTo("OWNER10");
+
+        mockMvc.perform(get("/api/article/" + savedArticle.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ownerCommissionPromoCode").value("OWNER10"));
+
+        mockMvc.perform(get("/api/article/my-articles/" + savedOwner.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value(savedArticle.getId()))
+            .andExpect(jsonPath("$[0].ownerCommissionPromoCode").value("OWNER10"));
     }
 
     // Test Filtros My Articles 

--- a/backend/src/test/java/com/example/demo/article/ArticleServiceTest.java
+++ b/backend/src/test/java/com/example/demo/article/ArticleServiceTest.java
@@ -343,6 +343,21 @@ class ArticleServiceTest {
         verify(articleRepository).save(article);
     }
 
+    @Test
+    void save_withOwnerCommissionPromoCode_normalizesValidatesAndPersists() {
+        article.setOwnerCommissionPromoCode(" owner10 ");
+        when(promoCodeService.validateForOwnerCommissionReductionAllowReservedByUser("OWNER10", "owner@example.com"))
+                .thenReturn(new PromoCodeValidationResponse(true, 0.10, "Código aplicado correctamente"));
+        when(articleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Article result = articleService.save(article);
+
+        assertThat(result.getOwnerCommissionPromoCode()).isEqualTo("OWNER10");
+        verify(promoCodeService).validateForOwnerCommissionReductionAllowReservedByUser("OWNER10", "owner@example.com");
+        verify(promoCodeService).reserveOwnerSingleUseIfNeeded("OWNER10", "owner@example.com");
+        verify(articleRepository).save(argThat(saved -> "OWNER10".equals(saved.getOwnerCommissionPromoCode())));
+    }
+
     // ------------ UPDATE /api/article/{id} ------------
 
     @Test

--- a/mobile/__tests__/profile/myArticlesOwnerPromoBadge.test.ts
+++ b/mobile/__tests__/profile/myArticlesOwnerPromoBadge.test.ts
@@ -1,0 +1,62 @@
+import { formatOwnerCommissionPromoBadgeLabel } from '../../src/utils/ownerCommissionPromo';
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs: any = require('fs');
+const path: any = require('path');
+
+declare const __dirname: string;
+
+const screenPath = path.resolve(__dirname, '../../src/screens/profile/MyArticlesScreen.tsx');
+const uploadArticleScreenPath = path.resolve(__dirname, '../../src/screens/profile/UploadArticleScreen.tsx');
+const typesPath = path.resolve(__dirname, '../../src/types/index.ts');
+const articleServicePath = path.resolve(__dirname, '../../src/services/articleService.ts');
+
+const screenSource = fs.readFileSync(screenPath, 'utf-8');
+const uploadArticleScreenSource = fs.readFileSync(uploadArticleScreenPath, 'utf-8');
+const typesSource = fs.readFileSync(typesPath, 'utf-8');
+const articleServiceSource = fs.readFileSync(articleServicePath, 'utf-8');
+
+describe('MyArticles owner commission promo badge', () => {
+  it('formatea el badge como descuento de comisión para evitar ambigüedad', () => {
+    expect(formatOwnerCommissionPromoBadgeLabel('OWNERPILOT10')).toBe('Descuento comisión: OWNERPILOT10');
+  });
+
+  it('normaliza espacios del código antes de mostrarlo', () => {
+    expect(formatOwnerCommissionPromoBadgeLabel('  OWNERPILOT10  ')).toBe('Descuento comisión: OWNERPILOT10');
+  });
+
+  it('no renderiza label cuando no hay código', () => {
+    expect(formatOwnerCommissionPromoBadgeLabel(null)).toBeNull();
+    expect(formatOwnerCommissionPromoBadgeLabel(undefined)).toBeNull();
+    expect(formatOwnerCommissionPromoBadgeLabel('   ')).toBeNull();
+  });
+
+  it('el tipo UserArticle acepta ownerCommissionPromoCode desde my-articles', () => {
+    expect(typesSource).toContain('export interface UserArticle');
+    expect(typesSource).toContain('ownerCommissionPromoCode?: string | null');
+  });
+
+  it('getMyArticles tipa la respuesta como UserArticle[]', () => {
+    expect(articleServiceSource).toContain('UserArticle');
+    expect(articleServiceSource).toContain('): Promise<UserArticle[]>');
+    expect(articleServiceSource).toContain('return handleResponse<UserArticle[]>(res)');
+  });
+
+  it('MyArticlesScreen renderiza un badge accesible solo cuando existe ownerCommissionPromoCode', () => {
+    expect(screenSource).toContain('formatOwnerCommissionPromoBadgeLabel(item.ownerCommissionPromoCode)');
+    expect(screenSource).toContain('ownerPromoBadgeLabel ?');
+    expect(screenSource).toContain('testID={`owner-promo-badge-${item.id}`}');
+    expect(screenSource).toContain('accessibilityLabel={ownerPromoBadgeLabel}');
+    expect(screenSource).toContain('{ownerPromoBadgeLabel}');
+  });
+
+  it('UploadArticleScreen valida el promo como descuento de comisión de arrendador', () => {
+    expect(uploadArticleScreenSource).toContain('validatePromoCode');
+    expect(uploadArticleScreenSource).toContain("'OWNER_COMMISSION_REDUCTION'");
+  });
+
+  it('UploadArticleScreen envía ownerCommissionPromoCode en el payload solo tras aplicar el código', () => {
+    expect(uploadArticleScreenSource).toContain('appliedOwnerPromoCode');
+    expect(uploadArticleScreenSource).toContain('ownerCommissionPromoCode: appliedOwnerPromoCode');
+  });
+});

--- a/mobile/src/screens/home/HomeScreen.tsx
+++ b/mobile/src/screens/home/HomeScreen.tsx
@@ -17,7 +17,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList, RentedItemResponse, Article, DeliveryStatus, KitResponse, DemandAnalysisItem } from '../../types';
+import { RootStackParamList, RentedItemResponse, UserArticle, DeliveryStatus, KitResponse, DemandAnalysisItem } from '../../types';
 import { Colors } from '../../styles';
 import { getLoggedUserWallet, getRentedItems, getMyArticles, getTopDemandedItems } from '../../services';
 import { SkeletonPulse, FadeInItem } from '../../components';
@@ -53,7 +53,7 @@ const HomeScreen: React.FC = () => {
   const [loadingBalance, setLoadingBalance] = useState(false);
   const [rentedItems, setRentedItems] = useState<RentedItemResponse[]>([]);
   const [loadingRentals, setLoadingRentals] = useState(false);
-  const [myArticles, setMyArticles] = useState<Article[]>([]);
+  const [myArticles, setMyArticles] = useState<UserArticle[]>([]);
   const [loadingArticles, setLoadingArticles] = useState(false);
   const [topDemandedItems, setTopDemandedItems] = useState<DemandAnalysisItem[]>([]);
   const [loadingTopDemanded, setLoadingTopDemanded] = useState(false);

--- a/mobile/src/screens/profile/MyArticlesScreen.tsx
+++ b/mobile/src/screens/profile/MyArticlesScreen.tsx
@@ -14,6 +14,7 @@ import { ConfirmModal } from '../../components/ConfirmModal';
 import { SelectPicker } from '../../components/SelectPicker';
 import { Provider as PaperProvider, MD3LightTheme } from 'react-native-paper';
 import { DatePickerModal, es, registerTranslation } from 'react-native-paper-dates';
+import { formatOwnerCommissionPromoBadgeLabel } from '../../utils/ownerCommissionPromo';
 
 type MyArticlesNav = NativeStackNavigationProp<RootStackParamList, 'MyArticles'>;
 type FilterType = 'ALL' | 'AVAILABLE' | 'RENTED';
@@ -431,6 +432,7 @@ const MyArticlesScreen: React.FC = () => {
   const renderArticle = ({ item }: { item: UserArticle }) => {
     const isDeleting = deletingId === item.id;
     const isExpanded = expandedId === item.id;
+    const ownerPromoBadgeLabel = formatOwnerCommissionPromoBadgeLabel(item.ownerCommissionPromoCode);
 
     return (
       <View style={styles.cardContainer}>
@@ -459,6 +461,18 @@ const MyArticlesScreen: React.FC = () => {
               <View style={[styles.statusBadge, { backgroundColor: getStatusColor(item.status), alignSelf: 'flex-start' }]}>
                 <Text style={styles.statusText}>{translateStatus(item.status)}</Text>
               </View>
+              {ownerPromoBadgeLabel ? (
+                <View
+                  style={styles.ownerPromoBadge}
+                  testID={`owner-promo-badge-${item.id}`}
+                  accessibilityLabel={ownerPromoBadgeLabel}
+                >
+                  <Ionicons name="pricetag-outline" size={13} color="#2f7d50" />
+                  <Text style={styles.ownerPromoText} numberOfLines={1}>
+                    {ownerPromoBadgeLabel}
+                  </Text>
+                </View>
+              ) : null}
             </View>
           </TouchableOpacity>
 
@@ -912,6 +926,25 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '600',
     color: '#fff',
+  },
+  ownerPromoBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginTop: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    backgroundColor: '#eaf7ef',
+    borderWidth: 1,
+    borderColor: '#bfe8cf',
+    maxWidth: '100%',
+  },
+  ownerPromoText: {
+    marginLeft: 4,
+    color: '#2f7d50',
+    fontSize: 12,
+    fontWeight: '700',
   },
   dateRow: {
     flexDirection: 'row',

--- a/mobile/src/services/articleService.ts
+++ b/mobile/src/services/articleService.ts
@@ -1,5 +1,5 @@
 import { API_ROUTES } from '../config/api';
-import { Article, ArticleNearby, ArticlePayload, ArticleRecordDTO } from '../types';
+import { Article, ArticleNearby, ArticlePayload, ArticleRecordDTO, UserArticle } from '../types';
 import { Platform } from 'react-native';
 
 const normalizeErrorMessage = (raw: string): string => {
@@ -40,7 +40,7 @@ export async function getMyArticles(
     minPrice?: number; 
     maxPrice?: number 
   }
-): Promise<Article[]> {
+): Promise<UserArticle[]> {
  
 
   let url = API_ROUTES.MY_ARTICLES(userId);
@@ -78,7 +78,7 @@ export async function getMyArticles(
     },
   });
   
-  return handleResponse<Article[]>(res);
+  return handleResponse<UserArticle[]>(res);
 }
 
 export async function getArticleById(id: number, token: string): Promise<Article> {

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -87,6 +87,7 @@ export interface UserArticle {
   pricePerMonth: number;
   status: "AVAILABLE" | "RENTED" | "INACTIVE";
   rentedUntil: string | null;
+  ownerCommissionPromoCode?: string | null;
   totalUnits?: number;
   rentals?: ArticleRecordDTO[];
 }

--- a/mobile/src/utils/ownerCommissionPromo.ts
+++ b/mobile/src/utils/ownerCommissionPromo.ts
@@ -1,0 +1,4 @@
+export function formatOwnerCommissionPromoBadgeLabel(promoCode?: string | null): string | null {
+  const normalizedCode = promoCode?.trim();
+  return normalizedCode ? `Descuento comisión: ${normalizedCode}` : null;
+}


### PR DESCRIPTION
Cambios

- Se expone ownerCommissionPromoCode en el DTO backend UserArticle.
- Se actualiza el mapeo de artículos para que GET /api/article/my-articles/{userId} devuelva el código aplicado.
- Se añade un badge visible en MyArticlesScreen con el texto: Descuento comisión: {CÓDIGO}.
- Se añade ownerCommissionPromoCode al tipo frontend UserArticle.
- Se actualiza getMyArticles() para devolver UserArticle[] en lugar de Article[].
- Se ajusta HomeScreen para consumir el tipo correcto.
- Se añaden tests backend para upload, detalle, listado de mis artículos y persistencia.
- Se añaden tests frontend para el texto del badge, renderizado condicional, payload de subida y validación del código owner.

Testing

- Pasan los tests backend relacionados con artículos.
- Pasan los tests de promo codes en backend.
- Pasa el test frontend del badge de descuento.



Se cambia getMyArticles() de Article[] a UserArticle[] porque el endpoint GET /api/article/my-articles/{userId} no devuelve artículos completos, sino un DTO resumido para listados.

Esto evita que el frontend asuma campos que no llegan desde la API, como description, category, availableFrom o availableUntil, y alinea el tipo TypeScript con la respuesta real del backend. También permite exponer correctamente ownerCommissionPromoCode en el listado de “Mis artículos”.