### PR TITLE
fix: services now change units depending on the date

### DIFF
--- a/backend/src/main/java/com/example/demo/service/ItemService.java
+++ b/backend/src/main/java/com/example/demo/service/ItemService.java
@@ -64,7 +64,6 @@ public class ItemService {
             ItemCatalogResponse dto = toCatalogResponse(item);
             
             if (startDate != null && endDate != null) {
-                // 1. Con fechas: Buscamos solapamientos para TODOS los ítems (Artículos y Servicios)
                 List<Kit> overlappingKits = kitRepository.findOverlappingKitsForItem(
                     item.getId(), startDate, endDate,
                     List.of(KitStatus.PAID, KitStatus.ACTIVE)
@@ -72,7 +71,6 @@ public class ItemService {
 
                 if (!overlappingKits.isEmpty()) {
                     int maxRented = 0;
-                    // Calculamos el pico máximo de unidades ocupadas en el periodo
                     for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
                         int rentedToday = 0;
                         for (Kit kit : overlappingKits) {
@@ -88,23 +86,19 @@ public class ItemService {
                         }
                     }
 
-                    // Calculamos lo que queda libre y actualizamos el DTO
                     int available = dto.getTotalUnits() - maxRented;
                     dto.setTotalUnits(Math.max(0, available));
 
-                    // Ajustamos el estado solo si es un Artículo
                     if ("ARTICLE".equals(dto.getItemType())) {
                         if (available <= 0) dto.setStatus("RENTED");
                         else dto.setStatus("AVAILABLE");
                     }
                 } else {
-                    // Si no hay solapamiento y es Artículo, está libre
                     if ("ARTICLE".equals(dto.getItemType())) {
                         dto.setStatus("AVAILABLE");
                     }
                 }
             } else if ("ARTICLE".equals(dto.getItemType())) {
-                // 2. Sin fechas: Mantenemos tu lógica original intacta (exclusiva para ARTICLE)
                 boolean isRentedInKit = articleRepository.findAllKitsWhereArticleHasBeen(item.getId())
                     .stream()
                     .anyMatch(k -> k.getStatus() == KitStatus.PAID || k.getStatus() == KitStatus.ACTIVE);

--- a/backend/src/main/java/com/example/demo/service/ItemService.java
+++ b/backend/src/main/java/com/example/demo/service/ItemService.java
@@ -7,6 +7,7 @@ import com.example.demo.model.Article;
 import com.example.demo.model.ArticleCondition;
 import com.example.demo.model.Item;
 import com.example.demo.model.ItemFilter;
+import com.example.demo.model.Kit;
 import com.example.demo.model.KitStatus;
 import com.example.demo.model.ServiceItem;
 import com.example.demo.repository.ArticleRepository;
@@ -61,23 +62,57 @@ public class ItemService {
 
         Page<ItemCatalogResponse> resultPage = itemRepository.findAll(spec, pageable).map(item -> {
             ItemCatalogResponse dto = toCatalogResponse(item);
-            if ("ARTICLE".equals(dto.getItemType())) {
-                boolean isRentedInKit;
-                if (startDate != null && endDate != null) {
-                    // Solo RENTED si hay solapamiento real de fechas
-                    isRentedInKit = !kitRepository.findOverlappingKitsForItem(
-                        item.getId(), startDate, endDate,
-                        List.of(KitStatus.PAID, KitStatus.ACTIVE)
-                    ).isEmpty();
+            
+            if (startDate != null && endDate != null) {
+                // 1. Con fechas: Buscamos solapamientos para TODOS los ítems (Artículos y Servicios)
+                List<Kit> overlappingKits = kitRepository.findOverlappingKitsForItem(
+                    item.getId(), startDate, endDate,
+                    List.of(KitStatus.PAID, KitStatus.ACTIVE)
+                );
+
+                if (!overlappingKits.isEmpty()) {
+                    int maxRented = 0;
+                    // Calculamos el pico máximo de unidades ocupadas en el periodo
+                    for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                        int rentedToday = 0;
+                        for (Kit kit : overlappingKits) {
+                            if (!date.isBefore(kit.getStartDate()) && !date.isAfter(kit.getEndDate())) {
+                                rentedToday += kit.getSnapshots().stream()
+                                    .filter(snap -> snap.getOriginalItemId().equals(item.getId()))
+                                    .mapToInt(snap -> snap.getSelectedUnits())
+                                    .sum();
+                            }
+                        }
+                        if (rentedToday > maxRented) {
+                            maxRented = rentedToday;
+                        }
+                    }
+
+                    // Calculamos lo que queda libre y actualizamos el DTO
+                    int available = dto.getTotalUnits() - maxRented;
+                    dto.setTotalUnits(Math.max(0, available));
+
+                    // Ajustamos el estado solo si es un Artículo
+                    if ("ARTICLE".equals(dto.getItemType())) {
+                        if (available <= 0) dto.setStatus("RENTED");
+                        else dto.setStatus("AVAILABLE");
+                    }
                 } else {
-                    // Sin fechas, marcar como RENTED si tiene kit activo
-                    isRentedInKit = articleRepository.findAllKitsWhereArticleHasBeen(item.getId())
-                        .stream()
-                        .anyMatch(k -> k.getStatus() == KitStatus.PAID || k.getStatus() == KitStatus.ACTIVE);
+                    // Si no hay solapamiento y es Artículo, está libre
+                    if ("ARTICLE".equals(dto.getItemType())) {
+                        dto.setStatus("AVAILABLE");
+                    }
                 }
+            } else if ("ARTICLE".equals(dto.getItemType())) {
+                // 2. Sin fechas: Mantenemos tu lógica original intacta (exclusiva para ARTICLE)
+                boolean isRentedInKit = articleRepository.findAllKitsWhereArticleHasBeen(item.getId())
+                    .stream()
+                    .anyMatch(k -> k.getStatus() == KitStatus.PAID || k.getStatus() == KitStatus.ACTIVE);
+                
                 if (isRentedInKit) dto.setStatus("RENTED");
                 else dto.setStatus("AVAILABLE");
             }
+            
             return dto;
         });
 


### PR DESCRIPTION
Como arrendador, creo un servicio de prueba que tiene un total de 10 unidades.

Como arrendatario, alquilo 5 unidades en un periodo de tiempo válido, confirmando la recepción del kit y por ende confirmando que ese servicio esta alquilado.

Como arrendatario, de nuevo, voy a crear un kit y a la hora de seleccionar los productos me encuentro con que el servicio de prueba esta disponible, y que además me deja seleccionar 10 unidades. Eso si, a la hora de confirmar el kit para pagarlo, el sistema me dice que no hay suficientes unidades.

El correcto funcionamiento sería que el front te diga que solo existen 5 unidades disponibles directamente.