### PR TITLE
fix: hide unavailable items from map selection

### DIFF
--- a/backend/src/main/java/com/example/demo/controller/ArticleController.java
+++ b/backend/src/main/java/com/example/demo/controller/ArticleController.java
@@ -260,9 +260,12 @@ public class ArticleController {
 
     @GetMapping("/map")
     public ResponseEntity<List<ArticleNearbyDTO>> getArticlesForMap(
-            @RequestParam(required = false) String country) {
+            @RequestParam(required = false) String country,
+            @RequestParam(defaultValue = "false") boolean includeRented) {
         try {
-            List<ArticleNearbyDTO> articles = articleService.findAllWithCoords(country);
+            List<ArticleNearbyDTO> articles = includeRented
+                ? articleService.findAllWithCoords(country, true)
+                : articleService.findAllWithCoords(country);
             return ResponseEntity.ok(articles);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);

--- a/backend/src/main/java/com/example/demo/repository/ArticleRepository.java
+++ b/backend/src/main/java/com/example/demo/repository/ArticleRepository.java
@@ -31,6 +31,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, JpaSpec
 
     List<Article> findByStatus(ArticleStatus status);
 
+    List<Article> findByStatusIn(List<ArticleStatus> statuses);
+
     @Query("SELECT k FROM Kit k JOIN k.snapshots s WHERE s.originalItemId = :articleId")
     List<Kit> findAllKitsWhereArticleHasBeen(@Param("articleId") Long articleId);
 

--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -510,7 +510,13 @@ public class ArticleService {
     }
 
     public List<ArticleNearbyDTO> findAllWithCoords(String country) {
-        List<Article> articles = articleRepository.findByStatus(ArticleStatus.AVAILABLE);
+        return findAllWithCoords(country, false);
+    }
+
+    public List<ArticleNearbyDTO> findAllWithCoords(String country, boolean includeRented) {
+        List<Article> articles = includeRented
+            ? articleRepository.findByStatusIn(List.of(ArticleStatus.AVAILABLE, ArticleStatus.RENTED))
+            : articleRepository.findByStatus(ArticleStatus.AVAILABLE);
         return articles.stream().map(article -> {
             String resolvedCountry = article.getCountry() != null ? article.getCountry() : country;
             CityCoordinatesDTO coords = resolvedCountry != null

--- a/backend/src/test/java/com/example/demo/article/NearbyArticleControllerTest.java
+++ b/backend/src/test/java/com/example/demo/article/NearbyArticleControllerTest.java
@@ -1,6 +1,8 @@
 package com.example.demo.article;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -203,6 +205,21 @@ class NearbyArticleControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].city").value("Madrid"));
+    }
+
+    @Test
+    void getArticlesForMap_whenIncludeRentedTrue_usesExpandedMapQuery() throws Exception {
+        when(articleService.findAllWithCoords("España", true))
+            .thenReturn(List.of(sampleDTO(1L, "Madrid", 0.0)));
+
+        mockMvc.perform(get("/api/article/map")
+                .param("country", "España")
+                .param("includeRented", "true"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(1));
+
+        verify(articleService).findAllWithCoords("España", true);
+        verify(articleService, never()).findAllWithCoords("España");
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/article/NearbyArticleServiceTest.java
+++ b/backend/src/test/java/com/example/demo/article/NearbyArticleServiceTest.java
@@ -302,6 +302,29 @@ class NearbyArticleServiceTest {
     }
 
     @Test
+    void findAllWithCoords_whenIncludeRentedTrue_returnsAvailableAndRentedArticles() {
+        Article available = createArticle(1L, "Taladro disponible", "Madrid", 30.0);
+        available.setCountry("España");
+
+        Article rentedWithStock = createArticle(2L, "Cámara alquilada parcialmente", "Barcelona", 45.0);
+        rentedWithStock.setCountry("España");
+        rentedWithStock.setStatus(ArticleStatus.RENTED);
+        rentedWithStock.setTotalUnits(2);
+
+        when(articleRepository.findByStatusIn(List.of(ArticleStatus.AVAILABLE, ArticleStatus.RENTED)))
+            .thenReturn(List.of(available, rentedWithStock));
+        when(cityService.getCityCoordinates("Madrid", "España")).thenReturn(MADRID_COORDS);
+        when(cityService.getCityCoordinates("Barcelona", "España")).thenReturn(BARCELONA_COORDS);
+
+        List<ArticleNearbyDTO> result = articleService.findAllWithCoords("España", true);
+
+        assertEquals(2, result.size());
+        assertEquals("AVAILABLE", result.get(0).status());
+        assertEquals("RENTED", result.get(1).status());
+        assertEquals(2, result.get(1).totalUnits());
+    }
+
+    @Test
     void findAllWithCoords_usesArticleCountryWhenAvailable() {
         Article a = createArticle(1L, "Taladro", "Madrid", 30.0);
         a.setCountry("España");

--- a/backend/src/test/java/com/example/demo/controller/ItemControllerTest.java
+++ b/backend/src/test/java/com/example/demo/controller/ItemControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,6 +81,46 @@ class ItemControllerTest {
                 .andExpect(jsonPath("$.content[0].title").value("Taladro"))
                 .andExpect(jsonPath("$.content[0].condition").value("USED"))
                 .andExpect(jsonPath("$.content[0].status").value("AVAILABLE"));
+    }
+
+    @Test
+    void filterItemsForKit_withRequestedDates_returnsAvailabilityFromService() throws Exception {
+        LocalDate startDate = LocalDate.of(2026, 5, 10);
+        LocalDate endDate = LocalDate.of(2026, 5, 12);
+
+        ItemCatalogResponse item = new ItemCatalogResponse();
+        item.setId(2L);
+        item.setTitle("Taladro ya reservado");
+        item.setPricePerMonth(25.0);
+        item.setStatus("RENTED");
+        item.setItemType("ARTICLE");
+        item.setTotalUnits(0);
+        item.setAvailableFrom(LocalDate.of(2026, 5, 1));
+        item.setAvailableUntil(LocalDate.of(2026, 5, 31));
+
+        ItemFilterResponseDTO response = new ItemFilterResponseDTO(List.of(item), 0, 100, 1, 1, false, false);
+
+        when(itemService.filterItemsForKit(isNull(), isNull(), isNull(), eq("Sevilla"), isNull(), isNull(), eq(0), eq(100), eq(startDate), eq(endDate)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/api/items/filter-for-kit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "city": "Sevilla",
+                                  "page": 0,
+                                  "size": 100,
+                                  "startDate": "2026-05-10",
+                                  "endDate": "2026-05-12"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(2))
+                .andExpect(jsonPath("$.content[0].status").value("RENTED"))
+                .andExpect(jsonPath("$.content[0].totalUnits").value(0))
+                .andExpect(jsonPath("$.content[0].availableFrom").value("2026-05-01"))
+                .andExpect(jsonPath("$.content[0].availableUntil").value("2026-05-31"));
     }
 
     @Test

--- a/backend/src/test/java/com/example/demo/service/ItemServiceTest.java
+++ b/backend/src/test/java/com/example/demo/service/ItemServiceTest.java
@@ -7,12 +7,16 @@ import com.example.demo.model.ArticleStatus;
 import com.example.demo.model.Category;
 import com.example.demo.model.CategoryStatus;
 import com.example.demo.model.Item;
+import com.example.demo.model.ItemMemento;
+import com.example.demo.model.Kit;
+import com.example.demo.model.KitStatus;
 import com.example.demo.model.ServiceItem;
 import com.example.demo.model.ServiceStatus;
 import com.example.demo.model.User;
 import com.example.demo.model.UserRole;
 import com.example.demo.repository.ItemRepository;
 import com.example.demo.repository.ArticleRepository;
+import com.example.demo.repository.KitRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +46,7 @@ class ItemServiceTest {
     @Mock private ArticleRepository articleRepository;
     @Mock private ItemRepository itemRepository;
     @Mock private DefaultKitService defaultKitService;
+    @Mock private KitRepository kitRepository;
 
     @InjectMocks
     private ItemService itemService;
@@ -97,6 +102,26 @@ class ItemServiceTest {
         return service;
     }
 
+    private Kit makeKitWithSnapshot(
+            Long itemId,
+            int selectedUnits,
+            LocalDate startDate,
+            LocalDate endDate,
+            KitStatus status
+    ) {
+        Kit kit = new Kit();
+        kit.setStartDate(startDate);
+        kit.setEndDate(endDate);
+        kit.setStatus(status);
+
+        ItemMemento snapshot = new ItemMemento();
+        snapshot.setOriginalItemId(itemId);
+        snapshot.setSelectedUnits(selectedUnits);
+        kit.setSnapshots(List.of(snapshot));
+
+        return kit;
+    }
+
     @Test
     void filterItemsForKit_withConditionAndPriceRange_returnsMappedResponse() {
         List<Item> items = List.of(
@@ -120,6 +145,58 @@ class ItemServiceTest {
         assertThat(result.getSize()).isEqualTo(10);
 
         verify(itemRepository).findAll(org.mockito.ArgumentMatchers.<Specification<Item>>any(), eq(PageRequest.of(0, 10)));
+    }
+
+    @Test
+    void filterItemsForKit_whenArticleFullyBookedForRequestedDates_returnsZeroUnitsAndRentedStatus() {
+        LocalDate startDate = LocalDate.of(2026, 5, 10);
+        LocalDate endDate = LocalDate.of(2026, 5, 12);
+        Article article = makeArticle(1L, ArticleCondition.USED, ArticleStatus.AVAILABLE, 25.0);
+        article.setTotalUnits(2);
+
+        Page<Item> page = new PageImpl<>(List.of(article), PageRequest.of(0, 10), 1);
+        Kit paidKit = makeKitWithSnapshot(1L, 2, startDate, endDate, KitStatus.PAID);
+
+        when(itemRepository.findAll(org.mockito.ArgumentMatchers.<Specification<Item>>any(), eq(PageRequest.of(0, 10)))).thenReturn(page);
+        when(kitRepository.findOverlappingKitsForItem(
+                eq(1L),
+                eq(startDate),
+                eq(endDate),
+                eq(List.of(KitStatus.PAID, KitStatus.ACTIVE))
+        )).thenReturn(List.of(paidKit));
+
+        ItemFilterResponseDTO result = itemService.filterItemsForKit(null, null, null, null, null, null, 0, 10, startDate, endDate);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).getTotalUnits()).isZero();
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo("RENTED");
+    }
+
+    @Test
+    void filterItemsForKit_whenOnlySomeUnitsAreBookedForRequestedDates_returnsRemainingUnitsAndAvailableStatus() {
+        LocalDate startDate = LocalDate.of(2026, 5, 10);
+        LocalDate endDate = LocalDate.of(2026, 5, 13);
+        Article article = makeArticle(1L, ArticleCondition.USED, ArticleStatus.AVAILABLE, 25.0);
+        article.setTotalUnits(3);
+
+        Page<Item> page = new PageImpl<>(List.of(article), PageRequest.of(0, 10), 1);
+        Kit firstOverlappingKit = makeKitWithSnapshot(1L, 2, LocalDate.of(2026, 5, 10), LocalDate.of(2026, 5, 11), KitStatus.PAID);
+        Kit secondOverlappingKit = makeKitWithSnapshot(1L, 1, LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 13), KitStatus.ACTIVE);
+
+        when(itemRepository.findAll(org.mockito.ArgumentMatchers.<Specification<Item>>any(), eq(PageRequest.of(0, 10)))).thenReturn(page);
+        when(kitRepository.findOverlappingKitsForItem(
+                eq(1L),
+                eq(startDate),
+                eq(endDate),
+                eq(List.of(KitStatus.PAID, KitStatus.ACTIVE))
+        )).thenReturn(List.of(firstOverlappingKit, secondOverlappingKit));
+
+        ItemFilterResponseDTO result = itemService.filterItemsForKit(null, null, null, null, null, null, 0, 10, startDate, endDate);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTotalUnits()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo("AVAILABLE");
     }
 
     @Test

--- a/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
+++ b/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
@@ -107,7 +107,7 @@ describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
       },
       TOKEN,
     );
-    const mapResponse = await getArticlesForMap(TOKEN, "España");
+    const mapResponse = await getArticlesForMap(TOKEN, "España", true);
 
     const mapArticles = buildSelectableKitMapProducts(
       mapResponse,
@@ -151,6 +151,11 @@ describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("country=Espa"),
+      expect.any(Object),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("includeRented=true"),
       expect.any(Object),
     );
 

--- a/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
+++ b/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
@@ -1,0 +1,147 @@
+jest.mock("react-native", () => ({ Platform: { OS: "web" } }));
+
+import { getArticlesForMap } from "../../src/services/articleService";
+import { filterItemsForKit } from "../../src/services/kitService";
+import { buildSelectableKitMapProducts } from "../../src/utils/kitAvailability";
+
+const mockFetch = jest.fn() as jest.Mock;
+(globalThis as any).fetch = mockFetch;
+
+const TOKEN = "tenant-token";
+const startDate = new Date("2026-05-10T00:00:00.000Z");
+const endDate = new Date("2026-05-12T00:00:00.000Z");
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  }) as Response;
+
+describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("reproduce el flujo y evita que el mapa muestre un item no disponible en el rango", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: [
+            {
+              id: 1,
+              itemType: "ARTICLE",
+              title: "Taladro disponible",
+              status: "AVAILABLE",
+              totalUnits: 1,
+              availableFrom: "2026-05-01",
+              availableUntil: "2026-05-31",
+              city: "Sevilla",
+              pricePerMonth: 15,
+            },
+            {
+              id: 2,
+              itemType: "ARTICLE",
+              title: "Taladro ya reservado",
+              status: "RENTED",
+              totalUnits: 0,
+              availableFrom: "2026-05-01",
+              availableUntil: "2026-05-31",
+              city: "Sevilla",
+              pricePerMonth: 15,
+            },
+          ],
+          page: 0,
+          size: 100,
+          totalElements: 2,
+          totalPages: 1,
+          hasNext: false,
+          hasPrevious: false,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            title: "Taladro disponible",
+            city: "Sevilla",
+            ownerName: "Ana",
+            pricePerMonth: 15,
+            cityLat: 37.3891,
+            cityLng: -5.9845,
+          },
+          {
+            id: 2,
+            title: "Taladro ya reservado",
+            city: "Sevilla",
+            ownerName: "Luis",
+            pricePerMonth: 15,
+            cityLat: 37.3891,
+            cityLng: -5.9845,
+          },
+          {
+            id: 999,
+            title: "Articulo presente solo en mapa",
+            city: "Sevilla",
+            ownerName: "Marta",
+            pricePerMonth: 20,
+            cityLat: 37.3891,
+            cityLng: -5.9845,
+          },
+        ]),
+      );
+
+    const catalogResponse = await filterItemsForKit(
+      {
+        country: undefined,
+        city: "Sevilla",
+        page: 0,
+        size: 100,
+        startDate: "2026-05-10",
+        endDate: "2026-05-12",
+      },
+      TOKEN,
+    );
+    const mapResponse = await getArticlesForMap(TOKEN, "España");
+
+    const mapArticles = buildSelectableKitMapProducts(
+      mapResponse,
+      catalogResponse.content,
+      {
+        startDate,
+        endDate,
+        showOnlyMyCity: true,
+        userCity: "Sevilla",
+      },
+    );
+
+    const [catalogUrl, catalogOptions] = mockFetch.mock.calls[0];
+    expect(catalogUrl).toContain("/api/items/filter-for-kit");
+    expect(catalogOptions.method).toBe("POST");
+    expect(JSON.parse(catalogOptions.body)).toEqual(
+      expect.objectContaining({
+        city: "Sevilla",
+        startDate: "2026-05-10",
+        endDate: "2026-05-12",
+      }),
+    );
+
+    const [mapUrl, mapOptions] = mockFetch.mock.calls[1];
+    expect(mapUrl).toContain("/api/article/map");
+    expect(mapUrl).toContain("country=Espa");
+    expect(mapOptions.method).toBe("GET");
+
+    expect(mapArticles.map((article) => article.id)).toEqual([1]);
+    expect(mapArticles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 2 }),
+        expect.objectContaining({ id: 999 }),
+      ]),
+    );
+  });
+});

--- a/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
+++ b/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
@@ -4,8 +4,8 @@ import { getArticlesForMap } from "../../src/services/articleService";
 import { filterItemsForKit } from "../../src/services/kitService";
 import { buildSelectableKitMapProducts } from "../../src/utils/kitAvailability";
 
-const mockFetch = jest.fn() as jest.Mock;
-(globalThis as any).fetch = mockFetch;
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+globalThis.fetch = mockFetch;
 
 const TOKEN = "tenant-token";
 const startDate = new Date("2026-05-10T00:00:00.000Z");
@@ -22,6 +22,21 @@ const jsonResponse = (body: unknown, status = 200) =>
     text: () => Promise.resolve(JSON.stringify(body)),
     json: () => Promise.resolve(body),
   }) as Response;
+
+const getFetchCall = (index: number): [RequestInfo | URL, RequestInit] => {
+  const call = mockFetch.mock.calls[index];
+  expect(call).toBeDefined();
+
+  const [url, options] = call;
+  expect(options).toBeDefined();
+
+  return [url, options as RequestInit];
+};
+
+const parseJsonBody = (body: BodyInit | null | undefined): unknown => {
+  expect(typeof body).toBe("string");
+  return JSON.parse(body as string);
+};
 
 describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
   beforeEach(() => {
@@ -120,10 +135,10 @@ describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
       },
     );
 
-    const [catalogUrl, catalogOptions] = mockFetch.mock.calls[0];
-    expect(catalogUrl).toContain("/api/items/filter-for-kit");
+    const [catalogUrl, catalogOptions] = getFetchCall(0);
+    expect(String(catalogUrl)).toContain("/api/items/filter-for-kit");
     expect(catalogOptions.method).toBe("POST");
-    expect(JSON.parse(catalogOptions.body)).toEqual(
+    expect(parseJsonBody(catalogOptions.body)).toEqual(
       expect.objectContaining({
         city: "Sevilla",
         startDate: "2026-05-10",
@@ -131,9 +146,9 @@ describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
       }),
     );
 
-    const [mapUrl, mapOptions] = mockFetch.mock.calls[1];
-    expect(mapUrl).toContain("/api/article/map");
-    expect(mapUrl).toContain("country=Espa");
+    const [mapUrl, mapOptions] = getFetchCall(1);
+    expect(String(mapUrl)).toContain("/api/article/map");
+    expect(String(mapUrl)).toContain("country=Espa");
     expect(mapOptions.method).toBe("GET");
 
     expect(mapArticles.map((article) => article.id)).toEqual([1]);

--- a/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
+++ b/mobile/__tests__/kits/createKitMapAvailability.e2e.test.ts
@@ -23,21 +23,6 @@ const jsonResponse = (body: unknown, status = 200) =>
     json: () => Promise.resolve(body),
   }) as Response;
 
-const getFetchCall = (index: number): [RequestInfo | URL, RequestInit] => {
-  const call = mockFetch.mock.calls[index];
-  expect(call).toBeDefined();
-
-  const [url, options] = call;
-  expect(options).toBeDefined();
-
-  return [url, options as RequestInit];
-};
-
-const parseJsonBody = (body: BodyInit | null | undefined): unknown => {
-  expect(typeof body).toBe("string");
-  return JSON.parse(body as string);
-};
-
 describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -135,21 +120,39 @@ describe("E2E ligero CU-ARRENDATARIO-01 lista/mapa", () => {
       },
     );
 
-    const [catalogUrl, catalogOptions] = getFetchCall(0);
-    expect(String(catalogUrl)).toContain("/api/items/filter-for-kit");
-    expect(catalogOptions.method).toBe("POST");
-    expect(parseJsonBody(catalogOptions.body)).toEqual(
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/api/items/filter-for-kit"),
       expect.objectContaining({
-        city: "Sevilla",
-        startDate: "2026-05-10",
-        endDate: "2026-05-12",
+        method: "POST",
+        body: expect.stringContaining('"city":"Sevilla"'),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"startDate":"2026-05-10"'),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"endDate":"2026-05-12"'),
       }),
     );
 
-    const [mapUrl, mapOptions] = getFetchCall(1);
-    expect(String(mapUrl)).toContain("/api/article/map");
-    expect(String(mapUrl)).toContain("country=Espa");
-    expect(mapOptions.method).toBe("GET");
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/api/article/map"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("country=Espa"),
+      expect.any(Object),
+    );
 
     expect(mapArticles.map((article) => article.id)).toEqual([1]);
     expect(mapArticles).not.toEqual(

--- a/mobile/__tests__/kits/filterItemsForKitService.test.ts
+++ b/mobile/__tests__/kits/filterItemsForKitService.test.ts
@@ -1,0 +1,98 @@
+import { filterItemsForKit } from "../../src/services/kitService";
+
+const mockFetch = jest.fn() as jest.Mock;
+(globalThis as any).fetch = mockFetch;
+
+const TOKEN = "tenant-token";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    text: () => Promise.resolve(JSON.stringify(body)),
+  }) as Response;
+
+describe("filterItemsForKit service", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("envia las fechas del kit al endpoint de catalogo filtrado", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        content: [],
+        page: 0,
+        size: 100,
+        totalElements: 0,
+        totalPages: 0,
+        hasNext: false,
+        hasPrevious: false,
+      }),
+    );
+
+    await filterItemsForKit(
+      {
+        city: "Sevilla",
+        page: 0,
+        size: 100,
+        startDate: "2026-05-10",
+        endDate: "2026-05-12",
+      },
+      TOKEN,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/items/filter-for-kit");
+    expect(options.method).toBe("POST");
+    expect(options.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(JSON.parse(options.body)).toEqual(
+      expect.objectContaining({
+        city: "Sevilla",
+        page: 0,
+        size: 100,
+        startDate: "2026-05-10",
+        endDate: "2026-05-12",
+      }),
+    );
+  });
+
+  it("conserva totalUnits 0 cuando backend informa que no hay unidades disponibles", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        content: [
+          {
+            id: 2,
+            itemType: "ARTICLE",
+            title: "Taladro ya reservado",
+            status: "RENTED",
+            totalUnits: 0,
+          },
+        ],
+        page: 0,
+        size: 100,
+        totalElements: 1,
+        totalPages: 1,
+        hasNext: false,
+        hasPrevious: false,
+      }),
+    );
+
+    const response = await filterItemsForKit(
+      { page: 0, size: 100, startDate: "2026-05-10", endDate: "2026-05-12" },
+      TOKEN,
+    );
+
+    expect(response.content[0]).toEqual(
+      expect.objectContaining({
+        id: 2,
+        status: "RENTED",
+        totalUnits: 0,
+      }),
+    );
+  });
+});

--- a/mobile/__tests__/kits/filterItemsForKitService.test.ts
+++ b/mobile/__tests__/kits/filterItemsForKitService.test.ts
@@ -1,7 +1,7 @@
 import { filterItemsForKit } from "../../src/services/kitService";
 
-const mockFetch = jest.fn() as jest.Mock;
-(globalThis as any).fetch = mockFetch;
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+globalThis.fetch = mockFetch;
 
 const TOKEN = "tenant-token";
 
@@ -15,6 +15,21 @@ const jsonResponse = (body: unknown, status = 200) =>
     },
     text: () => Promise.resolve(JSON.stringify(body)),
   }) as Response;
+
+const getFetchCall = (index: number): [RequestInfo | URL, RequestInit] => {
+  const call = mockFetch.mock.calls[index];
+  expect(call).toBeDefined();
+
+  const [url, options] = call;
+  expect(options).toBeDefined();
+
+  return [url, options as RequestInit];
+};
+
+const parseJsonBody = (body: BodyInit | null | undefined): unknown => {
+  expect(typeof body).toBe("string");
+  return JSON.parse(body as string);
+};
 
 describe("filterItemsForKit service", () => {
   beforeEach(() => {
@@ -46,11 +61,13 @@ describe("filterItemsForKit service", () => {
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain("/api/items/filter-for-kit");
+    const [url, options] = getFetchCall(0);
+    expect(String(url)).toContain("/api/items/filter-for-kit");
     expect(options.method).toBe("POST");
-    expect(options.headers.Authorization).toBe(`Bearer ${TOKEN}`);
-    expect(JSON.parse(options.body)).toEqual(
+    expect((options.headers as { Authorization?: string }).Authorization).toBe(
+      `Bearer ${TOKEN}`,
+    );
+    expect(parseJsonBody(options.body)).toEqual(
       expect.objectContaining({
         city: "Sevilla",
         page: 0,

--- a/mobile/__tests__/kits/filterItemsForKitService.test.ts
+++ b/mobile/__tests__/kits/filterItemsForKitService.test.ts
@@ -16,21 +16,6 @@ const jsonResponse = (body: unknown, status = 200) =>
     text: () => Promise.resolve(JSON.stringify(body)),
   }) as Response;
 
-const getFetchCall = (index: number): [RequestInfo | URL, RequestInit] => {
-  const call = mockFetch.mock.calls[index];
-  expect(call).toBeDefined();
-
-  const [url, options] = call;
-  expect(options).toBeDefined();
-
-  return [url, options as RequestInit];
-};
-
-const parseJsonBody = (body: BodyInit | null | undefined): unknown => {
-  expect(typeof body).toBe("string");
-  return JSON.parse(body as string);
-};
-
 describe("filterItemsForKit service", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -61,19 +46,27 @@ describe("filterItemsForKit service", () => {
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, options] = getFetchCall(0);
-    expect(String(url)).toContain("/api/items/filter-for-kit");
-    expect(options.method).toBe("POST");
-    expect((options.headers as { Authorization?: string }).Authorization).toBe(
-      `Bearer ${TOKEN}`,
-    );
-    expect(parseJsonBody(options.body)).toEqual(
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/api/items/filter-for-kit"),
       expect.objectContaining({
-        city: "Sevilla",
-        page: 0,
-        size: 100,
-        startDate: "2026-05-10",
-        endDate: "2026-05-12",
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }),
+        body: expect.stringContaining('"city":"Sevilla"'),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"startDate":"2026-05-10"'),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"endDate":"2026-05-12"'),
       }),
     );
   });
@@ -104,12 +97,8 @@ describe("filterItemsForKit service", () => {
       TOKEN,
     );
 
-    expect(response.content[0]).toEqual(
-      expect.objectContaining({
-        id: 2,
-        status: "RENTED",
-        totalUnits: 0,
-      }),
-    );
+    expect(response.content).toEqual([
+      expect.objectContaining({ id: 2, status: "RENTED", totalUnits: 0 }),
+    ]);
   });
 });

--- a/mobile/__tests__/kits/kitAvailability.test.ts
+++ b/mobile/__tests__/kits/kitAvailability.test.ts
@@ -1,0 +1,219 @@
+import {
+  buildSelectableKitMapProducts,
+  filterMapProductsByCatalogAvailability,
+  isCatalogProductAvailableForKitRange,
+} from "../../src/utils/kitAvailability";
+
+const startDate = new Date("2026-05-10T00:00:00.000Z");
+const endDate = new Date("2026-05-12T00:00:00.000Z");
+
+describe("isCatalogProductAvailableForKitRange", () => {
+  it("marca como disponible un producto con estado rentable, unidades y rango compatible", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 1,
+        status: "AVAILABLE",
+        totalUnits: 2,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("marca como no disponible un producto sin unidades efectivas", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 2,
+        status: "AVAILABLE",
+        totalUnits: 0,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("marca como no disponible un servicio activo sin unidades efectivas", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 20,
+        status: "ACTIVE",
+        totalUnits: 0,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("permite un producto rentable sin fechas propias cuando el catalogo ya lo considera disponible", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 21,
+        status: "AVAILABLE",
+        totalUnits: 1,
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("marca como no disponible un producto alquilado aunque tenga fechas compatibles", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 3,
+        status: "RENTED",
+        totalUnits: 1,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("marca como no disponible un producto cuyo rango no cubre la reserva solicitada", () => {
+    const result = isCatalogProductAvailableForKitRange(
+      {
+        id: 4,
+        status: "AVAILABLE",
+        totalUnits: 1,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-11",
+      },
+      startDate,
+      endDate,
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
+describe("filterMapProductsByCatalogAvailability", () => {
+  const mapProducts = [
+    { id: 1, city: "Sevilla", title: "Taladro" },
+    { id: 2, city: "Sevilla", title: "Sierra" },
+    { id: 3, city: "Sevilla", title: "Cámara" },
+    { id: 4, city: "Madrid", title: "Bicicleta" },
+    { id: 999, city: "Sevilla", title: "Solo en mapa" },
+  ];
+
+  const catalogProducts = [
+    {
+      id: 1,
+      status: "AVAILABLE",
+      totalUnits: 2,
+      availableFrom: "2026-05-01",
+      availableUntil: "2026-05-31",
+    },
+    {
+      id: 2,
+      status: "AVAILABLE",
+      totalUnits: 0,
+      availableFrom: "2026-05-01",
+      availableUntil: "2026-05-31",
+    },
+    {
+      id: 3,
+      status: "RENTED",
+      totalUnits: 1,
+      availableFrom: "2026-05-01",
+      availableUntil: "2026-05-31",
+    },
+    {
+      id: 4,
+      status: "AVAILABLE",
+      totalUnits: 1,
+      availableFrom: "2026-05-01",
+      availableUntil: "2026-05-31",
+    },
+  ];
+
+  it("solo deja en el mapa productos presentes y disponibles en el catalogo filtrado", () => {
+    const result = filterMapProductsByCatalogAvailability(
+      mapProducts,
+      catalogProducts,
+      { startDate, endDate },
+    );
+
+    expect(result.map((product) => product.id)).toEqual([1, 4]);
+  });
+
+  it("mantiene el filtro de ciudad sobre los productos disponibles", () => {
+    const result = filterMapProductsByCatalogAvailability(
+      mapProducts,
+      catalogProducts,
+      {
+        startDate,
+        endDate,
+        showOnlyMyCity: true,
+        userCity: "sevilla",
+      },
+    );
+
+    expect(result.map((product) => product.id)).toEqual([1]);
+  });
+});
+
+describe("buildSelectableKitMapProducts", () => {
+  it("prepara solo los marcadores seleccionables que debe recibir ArticleMapView", () => {
+    const result = buildSelectableKitMapProducts(
+      [
+        {
+          id: 1,
+          city: "Sevilla",
+          title: "Taladro",
+          ownerName: "Ana",
+          pricePerMonth: 25,
+        },
+        {
+          id: 2,
+          city: "Sevilla",
+          title: "Sierra",
+          ownerName: null,
+          pricePerMonth: 30,
+        },
+      ],
+      [
+        {
+          id: 1,
+          status: "AVAILABLE",
+          totalUnits: 1,
+          availableFrom: "2026-05-01",
+          availableUntil: "2026-05-31",
+        },
+        {
+          id: 2,
+          status: "RENTED",
+          totalUnits: 0,
+          availableFrom: "2026-05-01",
+          availableUntil: "2026-05-31",
+        },
+      ],
+      { startDate, endDate },
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 1,
+        city: "Sevilla",
+        ownerName: "Ana",
+        isAvailableForDates: true,
+      }),
+    ]);
+  });
+});

--- a/mobile/__tests__/kits/kitMapSelection.integration.test.ts
+++ b/mobile/__tests__/kits/kitMapSelection.integration.test.ts
@@ -1,0 +1,97 @@
+import { buildSelectableKitMapProducts } from "../../src/utils/kitAvailability";
+
+describe("integracion frontend lista/mapa para disponibilidad de kits", () => {
+  const startDate = new Date("2026-05-10T00:00:00.000Z");
+  const endDate = new Date("2026-05-12T00:00:00.000Z");
+
+  it("no pasa al mapa articulos que el catalogo filtrado no permite seleccionar", () => {
+    const catalogProducts = [
+      {
+        id: 1,
+        status: "AVAILABLE",
+        totalUnits: 1,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      {
+        id: 2,
+        status: "RENTED",
+        totalUnits: 0,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-31",
+      },
+      {
+        id: 3,
+        status: "AVAILABLE",
+        totalUnits: 1,
+        availableFrom: "2026-05-01",
+        availableUntil: "2026-05-11",
+      },
+    ];
+
+    const mapProducts = [
+      {
+        id: 1,
+        title: "Taladro disponible",
+        city: "Sevilla",
+        ownerName: "Ana",
+        pricePerMonth: 15,
+        cityLat: 37.3891,
+        cityLng: -5.9845,
+      },
+      {
+        id: 2,
+        title: "Taladro ya reservado",
+        city: "Sevilla",
+        ownerName: "Luis",
+        pricePerMonth: 15,
+        cityLat: 37.3891,
+        cityLng: -5.9845,
+      },
+      {
+        id: 3,
+        title: "Sierra fuera de rango",
+        city: "Sevilla",
+        ownerName: "Marta",
+        pricePerMonth: 20,
+        cityLat: 37.3891,
+        cityLng: -5.9845,
+      },
+    ];
+
+    const articlesForMap = buildSelectableKitMapProducts(
+      mapProducts,
+      catalogProducts,
+      { startDate, endDate },
+    );
+
+    expect(articlesForMap.map((article) => article.id)).toEqual([1]);
+    expect(articlesForMap[0]).toEqual(
+      expect.objectContaining({
+        id: 1,
+        title: "Taladro disponible",
+        city: "Sevilla",
+        ownerName: "Ana",
+        isAvailableForDates: true,
+      }),
+    );
+  });
+
+  it("excluye articulos que existen solo en el endpoint de mapa pero no en el catalogo filtrado", () => {
+    const articlesForMap = buildSelectableKitMapProducts(
+      [
+        {
+          id: 999,
+          title: "Articulo stale del mapa",
+          city: "Sevilla",
+          ownerName: "Ana",
+          pricePerMonth: 15,
+        },
+      ],
+      [],
+      { startDate, endDate },
+    );
+
+    expect(articlesForMap).toEqual([]);
+  });
+});

--- a/mobile/src/components/ProductSelectionModal.tsx
+++ b/mobile/src/components/ProductSelectionModal.tsx
@@ -21,6 +21,12 @@ import { useAuth } from "../context/AuthContext";
 import { useNotification } from "./NotificationContext";
 import { requestArticleAvailabilityNotification } from "../services/articleService";
 import { SelectPicker } from "./SelectPicker";
+import {
+  buildSelectableKitMapProducts,
+  hasAvailableUnits,
+  isCatalogProductAvailableForKitRange,
+  isRentableStatus,
+} from "../utils/kitAvailability";
 
 const sanitizePriceInput = (value: string): string => value.replace(/\D/g, "");
 
@@ -29,6 +35,9 @@ const parsePrice = (value?: string): number | undefined => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
 };
+
+const formatDate = (date: Date): string =>
+  `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
 
 type ProductSelectionNav = NativeStackNavigationProp<
   RootStackParamList,
@@ -154,10 +163,6 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
   const [requestingIds, setRequestingIds] = React.useState<
     Record<number, boolean>
   >({});
-  const filteredProductIds = React.useMemo(
-    () => new Set(filteredProducts.map((product) => product.id)),
-    [filteredProducts],
-  );
   const resolvedCategoryOptions = React.useMemo(() => {
     if (categoryOptions && categoryOptions.length > 0) {
       return categoryOptions;
@@ -258,44 +263,50 @@ export const ProductSelectionModal: React.FC<ProductSelectionModalProps> = ({
   };
 
   // Calcular disponibilidad de productos basado en fechas para la LISTA
-const productsWithAvailability = React.useMemo(() => {
-    if (!startDate || !endDate) {
-      return filteredProducts.map((p) => ({ ...p, isAvailable: true }));
-    }
-
-    const requestStart = new Date(startDate);
-    requestStart.setHours(0, 0, 0, 0);
-    
-    const requestEnd = new Date(endDate);
-    requestEnd.setHours(0, 0, 0, 0);
-
+  const productsWithAvailability = React.useMemo(() => {
     const mapped = filteredProducts.map((p) => {
-      if (!p.availableFrom || !p.availableUntil) {
-        const isAvailable = p.status === "AVAILABLE" || p.status === "ACTIVE";
+      const isAvailable = isCatalogProductAvailableForKitRange(
+        p,
+        startDate,
+        endDate,
+      );
+
+      if (isAvailable) {
+        return { ...p, isAvailable: true };
+      }
+
+      if (!hasAvailableUnits(p.totalUnits)) {
         return {
           ...p,
-          isAvailable,
-          availabilityMessage: isAvailable ? undefined : "Sin fechas de disponibilidad",
+          isAvailable: false,
+          availabilityMessage: "Sin unidades disponibles",
         };
       }
 
-      const productFrom = new Date(p.availableFrom);
-      productFrom.setHours(0, 0, 0, 0);
-      
-      const productUntil = new Date(p.availableUntil);
-      productUntil.setHours(0, 0, 0, 0);
-
-      const isAvailable = requestStart >= productFrom && requestEnd <= productUntil;
-
-      if (!isAvailable) {
-        const formatDate = (date: Date) => {
-          return `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
+      if (!isRentableStatus(p.status)) {
+        return {
+          ...p,
+          isAvailable: false,
+          availabilityMessage: "No disponible",
         };
+      }
+
+      if (startDate && endDate && p.availableFrom && p.availableUntil) {
+        const productFrom = new Date(p.availableFrom);
+        productFrom.setHours(0, 0, 0, 0);
+
+        const productUntil = new Date(p.availableUntil);
+        productUntil.setHours(0, 0, 0, 0);
+
         const availabilityMessage = `Disponible: ${formatDate(productFrom)} - ${formatDate(productUntil)}`;
         return { ...p, isAvailable: false, availabilityMessage };
       }
 
-      return { ...p, isAvailable: true };
+      return {
+        ...p,
+        isAvailable: false,
+        availabilityMessage: "No disponible en estas fechas",
+      };
     });
 
     if (showOnlyAvailable) {
@@ -305,53 +316,26 @@ const productsWithAvailability = React.useMemo(() => {
     return mapped;
   }, [filteredProducts, startDate, endDate, showOnlyAvailable]);
 
-  // Productos para el mapa (con marca de disponibilidad, sin filtrar)
+  // Productos para el mapa: solo los seleccionables segun el catalogo filtrado.
   const mapProductsWithAvailability = React.useMemo(() => {
-    let products = (showOnlyMyCity && userCity
-      ? mapProducts.filter(
-          (a) =>
-            filteredProductIds.has(a.id) &&
-            a.city?.toLowerCase() === userCity.toLowerCase(),
-        )
-      : mapProducts.filter((a) => filteredProductIds.has(a.id))
-    ).map((a) => ({
-      ...a,
-      city: a.city ?? undefined,
-      ownerName: a.ownerName ?? undefined,
-    }));
-
-    if (!startDate || !endDate) {
-      return products;
-    }
-
-    const requestStart = new Date(startDate);
-    requestStart.setHours(0, 0, 0, 0);
-    
-    const requestEnd = new Date(endDate);
-    requestEnd.setHours(0, 0, 0, 0);
-
-    const processedProducts = products.map((product) => {
-      if (!product.availableFrom || !product.availableUntil) {
-        return { ...product, isAvailableForDates: false };
-      }
-
-      const productFrom = new Date(product.availableFrom);
-      productFrom.setHours(0, 0, 0, 0);
-      
-      const productUntil = new Date(product.availableUntil);
-      productUntil.setHours(0, 0, 0, 0);
-
-      const isAvailable = requestStart >= productFrom && requestEnd <= productUntil;
-      
-      return { ...product, isAvailableForDates: isAvailable };
-    });
-
-    if (showOnlyAvailable) {
-      return processedProducts.filter(p => p.isAvailableForDates === true);
-    }
-    
-    return processedProducts;
-  }, [mapProducts, filteredProductIds, showOnlyMyCity, userCity, startDate, endDate, showOnlyAvailable]);
+    return buildSelectableKitMapProducts(
+      mapProducts,
+      filteredProducts,
+      {
+        startDate,
+        endDate,
+        showOnlyMyCity,
+        userCity,
+      },
+    );
+  }, [
+    mapProducts,
+    filteredProducts,
+    showOnlyMyCity,
+    userCity,
+    startDate,
+    endDate,
+  ]);
   
   const navigateToUserReviews = (ownerId: number, ownerName: string) => {
     onDismiss();
@@ -614,8 +598,7 @@ const productsWithAvailability = React.useMemo(() => {
                   p.id,
                 );
                 const selectedQuantity = tempSelectedQuantities[p.id] ?? 1;
-                const isRentableStatus = p.status === "AVAILABLE" || p.status === "ACTIVE";
-                const canBeAdded = p.isAvailable && isRentableStatus;
+                const canBeAdded = p.isAvailable === true;
 
                 return (
                   <Pressable

--- a/mobile/src/config/api.ts
+++ b/mobile/src/config/api.ts
@@ -139,10 +139,13 @@ export const API_ROUTES = {
   ARTICLE_NEARBY: (city: string, country: string, radiusKm = 150) =>
     `${BASE_URL}/api/article/nearby?city=${encodeURIComponent(city)}&country=${encodeURIComponent(country)}&radiusKm=${radiusKm}`,
 
-  ARTICLE_MAP: (country?: string) =>
-    country
-      ? `${BASE_URL}/api/article/map?country=${encodeURIComponent(country)}`
-      : `${BASE_URL}/api/article/map`,
+  ARTICLE_MAP: (country?: string, includeRented: boolean = false) => {
+    const params = new URLSearchParams();
+    if (country) params.append("country", country);
+    if (includeRented) params.append("includeRented", "true");
+    const query = params.toString();
+    return `${BASE_URL}/api/article/map${query ? `?${query}` : ""}`;
+  },
 
   // Ciudades
   GET_CITIES: `${BASE_URL}/api/cities`,

--- a/mobile/src/screens/kit/CreateKitScreen.tsx
+++ b/mobile/src/screens/kit/CreateKitScreen.tsx
@@ -458,7 +458,11 @@ const CreateKitScreen: React.FC = () => {
 
     if (user?.token) {
       try {
-        const mapData = await getArticlesForMap(user.token, country.trim() || undefined);
+        const mapData = await getArticlesForMap(
+          user.token,
+          country.trim() || undefined,
+          true,
+        );
         setMapProducts(mapData);
       } catch (error) {
         console.warn('Error al cargar productos del mapa:', error);

--- a/mobile/src/screens/kit/CreateKitScreen.tsx
+++ b/mobile/src/screens/kit/CreateKitScreen.tsx
@@ -25,7 +25,7 @@ import {
 registerTranslation("es", es);
 
 import { useAuth } from "../../context/AuthContext";
-import { createKit, filterItemsForKit, getActiveServices } from "../../services/kitService";
+import { createKit, filterItemsForKit } from "../../services/kitService";
 import {
   getNearbyArticles,
   getArticlesForMap,
@@ -114,6 +114,11 @@ const CONDITION_OPTIONS = [
   { label: "Usado", value: "USED" },
   { label: "Desgastado", value: "WORN" },
 ];
+
+const normalizeTotalUnits = (value: unknown): number => {
+  const units = Number(value ?? 1);
+  return Number.isFinite(units) ? Math.max(0, units) : 1;
+};
 
 // Constantes de validación (movidas fuera del componente para garantizar su existencia)
 const MAX_KIT_NAME_LENGTH = 255;
@@ -311,7 +316,7 @@ const CreateKitScreen: React.FC = () => {
         ownerId: Number(p.ownerId),
         ownerName: p.ownerName ?? "",
         imageUrl: (p as any).imageUrl ?? null,
-        totalUnits: Math.max(1, Number(p.totalUnits ?? 1)),
+        totalUnits: normalizeTotalUnits(p.totalUnits),
         availableFrom: (p as any).availableFrom ?? undefined,
         availableUntil: (p as any).availableUntil ?? undefined,
       }));

--- a/mobile/src/services/articleService.ts
+++ b/mobile/src/services/articleService.ts
@@ -265,8 +265,9 @@ export async function getNearbyArticles(
 export async function getArticlesForMap(
   token: string,
   country?: string,
+  includeRented: boolean = false,
 ): Promise<ArticleNearby[]> {
-  const res = await fetch(API_ROUTES.ARTICLE_MAP(country), {
+  const res = await fetch(API_ROUTES.ARTICLE_MAP(country, includeRented), {
     method: 'GET',
     headers: { ...jsonHeaders, Authorization: `Bearer ${token}` },
   });

--- a/mobile/src/utils/kitAvailability.ts
+++ b/mobile/src/utils/kitAvailability.ts
@@ -1,0 +1,139 @@
+export type KitAvailabilityProduct = {
+  id: number;
+  status?: string | null;
+  totalUnits?: number | null;
+  availableFrom?: string | null;
+  availableUntil?: string | null;
+};
+
+export type KitMapProduct = {
+  id: number;
+  city?: string | null;
+};
+
+export type KitSelectableMapProduct<TProduct extends KitMapProduct> = Omit<
+  TProduct,
+  "city" | "ownerName"
+> & {
+  city?: string;
+  ownerName?: string;
+  isAvailableForDates: true;
+};
+
+const RENTABLE_STATUSES = new Set(["AVAILABLE", "ACTIVE"]);
+
+const toStartOfDay = (value?: Date | string | null): Date | null => {
+  if (!value) return null;
+
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  date.setHours(0, 0, 0, 0);
+  return date;
+};
+
+export const isRentableStatus = (status?: string | null): boolean =>
+  RENTABLE_STATUSES.has(status ?? "");
+
+export const hasAvailableUnits = (totalUnits?: number | null): boolean => {
+  if (totalUnits === undefined || totalUnits === null) return true;
+
+  const units = Number(totalUnits);
+  return Number.isFinite(units) && units > 0;
+};
+
+export const isCatalogProductAvailableForKitRange = (
+  product: KitAvailabilityProduct,
+  startDate?: Date | null,
+  endDate?: Date | null,
+): boolean => {
+  if (!isRentableStatus(product.status)) return false;
+  if (!hasAvailableUnits(product.totalUnits)) return false;
+
+  const requestStart = toStartOfDay(startDate);
+  const requestEnd = toStartOfDay(endDate);
+  if (!requestStart || !requestEnd) return true;
+
+  if (!product.availableFrom || !product.availableUntil) {
+    return true;
+  }
+
+  const productFrom = toStartOfDay(product.availableFrom);
+  const productUntil = toStartOfDay(product.availableUntil);
+  if (!productFrom || !productUntil) return false;
+
+  return requestStart >= productFrom && requestEnd <= productUntil;
+};
+
+export const buildAvailableCatalogProductIdSet = (
+  products: KitAvailabilityProduct[],
+  startDate?: Date | null,
+  endDate?: Date | null,
+): Set<number> =>
+  new Set(
+    products
+      .filter((product) =>
+        isCatalogProductAvailableForKitRange(product, startDate, endDate),
+      )
+      .map((product) => product.id),
+  );
+
+export const isSameCity = (
+  productCity?: string | null,
+  userCity?: string | null,
+): boolean =>
+  !!productCity &&
+  !!userCity &&
+  productCity.trim().toLowerCase() === userCity.trim().toLowerCase();
+
+export const filterMapProductsByCatalogAvailability = <
+  TProduct extends KitMapProduct,
+>(
+  mapProducts: TProduct[],
+  catalogProducts: KitAvailabilityProduct[],
+  options: {
+    startDate?: Date | null;
+    endDate?: Date | null;
+    showOnlyMyCity?: boolean;
+    userCity?: string;
+  } = {},
+): TProduct[] => {
+  const availableCatalogIds = buildAvailableCatalogProductIdSet(
+    catalogProducts,
+    options.startDate,
+    options.endDate,
+  );
+
+  return mapProducts.filter((product) => {
+    if (!availableCatalogIds.has(product.id)) return false;
+
+    if (options.showOnlyMyCity && options.userCity) {
+      return isSameCity(product.city, options.userCity);
+    }
+
+    return true;
+  });
+};
+
+export const buildSelectableKitMapProducts = <
+  TProduct extends KitMapProduct & { ownerName?: string | null },
+>(
+  mapProducts: TProduct[],
+  catalogProducts: KitAvailabilityProduct[],
+  options: {
+    startDate?: Date | null;
+    endDate?: Date | null;
+    showOnlyMyCity?: boolean;
+    userCity?: string;
+  } = {},
+): KitSelectableMapProduct<TProduct>[] =>
+  filterMapProductsByCatalogAvailability(
+    mapProducts,
+    catalogProducts,
+    options,
+  ).map((product) => ({
+    ...product,
+    city: product.city ?? undefined,
+    ownerName: product.ownerName ?? undefined,
+    isAvailableForDates: true,
+  }));


### PR DESCRIPTION
Cambios

- Se añade kitAvailability.ts para centralizar la lógica de disponibilidad de ítems en kits.
- Se valida disponibilidad usando estado, totalUnits y rango de fechas.
- Se corrige CreateKitScreen para conservar totalUnits = 0 cuando el backend indica que no hay unidades.
- Se evita que el frontend convierta totalUnits = 0 en totalUnits = 1.
- Se actualiza ProductSelectionModal para que lista y mapa usen la misma lógica de disponibilidad.
- Se hace que el mapa use el catálogo filtrado como fuente de verdad.
- Se evita que el mapa muestre ítems no disponibles, fuera de rango o ausentes del catálogo filtrado.
- Se mantiene el filtro por ciudad en los productos mostrados en el mapa.
- Se simplifica la selección para permitir añadir solo productos realmente disponibles.
- Se elimina un import no usado de getActiveServices.

Testing añadido

- Se añade kitAvailability.test.ts para disponibilidad por estado, unidades y fechas.
- Se cubren casos de totalUnits = 0, servicios ACTIVE sin unidades, RENTED y fuera de rango.
- Se añade kitMapSelection.integration.test.ts para validar consistencia entre lista y mapa.
- Se añade createKitMapAvailability.e2e.test.ts para cubrir el flujo catálogo + mapa.
- Se añade filterItemsForKitService.test.ts para comprobar envío de fechas y conservación de totalUnits = 0.
- Se añaden tests backend en ItemServiceTest para unidades disponibles con kits solapados.
- Se añade test backend en ItemControllerTest para el contrato de /api/items/filter-for-kit con fechas.

Tests ejecutados

- npm test -- --runInBand
- ./mvnw -Dtest=ItemServiceTest,ItemControllerTest test
- ./mvnw test
- git diff --check

Esta PR corrige la inconsistencia por la que un ítem no disponible podía desaparecer de la lista pero seguir apareciendo en el mapa. Ahora el mapa cruza sus resultados con el catálogo filtrado y solo muestra ítems realmente seleccionables para el rango de fechas del kit.

También se corrige el caso en el que el backend devolvía totalUnits = 0, pero el frontend lo transformaba a 1, haciendo que un ítem sin unidades pareciera disponible.