### PR TITLE
Fix/filtro solo productos en fechas seleccionadas

### DIFF
--- a/mobile/src/screens/kit/CreateKitScreen.tsx
+++ b/mobile/src/screens/kit/CreateKitScreen.tsx
@@ -433,7 +433,6 @@ const CreateKitScreen: React.FC = () => {
       return availableProducts.filter((p) => {
         const notInactive = p.itemType === "SERVICE" ? p.status === "ACTIVE" : p.status !== "INACTIVE";
         
-        // LA SOLUCIÓN: Nos fiamos solo del status, ignorando el totalUnits trampeado a 1
         const isAvailable = p.status === "AVAILABLE" || p.status === "ACTIVE";
         const passesAvailabilityFilter = showOnlyAvailable ? isAvailable : true;
 

--- a/mobile/src/screens/kit/CreateKitScreen.tsx
+++ b/mobile/src/screens/kit/CreateKitScreen.tsx
@@ -427,21 +427,27 @@ const CreateKitScreen: React.FC = () => {
     [catalogCategories],
   );
 
+    
   const filteredProducts = useMemo(() => {
-    const q = searchText.trim().toLowerCase();
-    return availableProducts.filter((p) => {
-      const notInactive = p.itemType === "SERVICE" ? p.status === "ACTIVE" : p.status !== "INACTIVE";
-      const bySearch =
-        q.length === 0 ||
-        p.title.toLowerCase().includes(q) ||
-        (p.city ?? "").toLowerCase().includes(q) ||
-        (p.category ?? "").toLowerCase().includes(q) ||
-        (p.ownerName ?? "").toLowerCase().includes(q) ||
-        (p.condition ?? "").toLowerCase().includes(q);
+      const q = searchText.trim().toLowerCase();
+      return availableProducts.filter((p) => {
+        const notInactive = p.itemType === "SERVICE" ? p.status === "ACTIVE" : p.status !== "INACTIVE";
+        
+        // LA SOLUCIÓN: Nos fiamos solo del status, ignorando el totalUnits trampeado a 1
+        const isAvailable = p.status === "AVAILABLE" || p.status === "ACTIVE";
+        const passesAvailabilityFilter = showOnlyAvailable ? isAvailable : true;
 
-      return notInactive && bySearch;
-    });
-  }, [availableProducts, searchText]);
+        const bySearch =
+          q.length === 0 ||
+          p.title.toLowerCase().includes(q) ||
+          (p.city ?? "").toLowerCase().includes(q) ||
+          (p.category ?? "").toLowerCase().includes(q) ||
+          (p.ownerName ?? "").toLowerCase().includes(q) ||
+          (p.condition ?? "").toLowerCase().includes(q);
+
+        return notInactive && bySearch && passesAvailabilityFilter;
+      });
+    }, [availableProducts, searchText, showOnlyAvailable]);
 
   const openAddProductModal = async () => {
     const useCityFilter = city.trim().length > 0;


### PR DESCRIPTION
**PARA PROBAR:**
- Se alquila un producto (se ha usado para reproducir el error el MacBook de Carlos Owner)

- Se crea un kit para las fechas donde esta alquilado el MacBook

- El MacBook sale en el filtro de "Solo productos disponibles en las fechas seleccionadas", cuando realmente no está disponible

- El comportamiento ideal creo que debría ser que no apareciera con ese filtro si realmente no esta disponible. Y que cuando quites el filtro si que aparezca.