### PR TITLE
fix: prevent future purchase dates

### DIFF
--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -35,6 +35,8 @@ import com.example.demo.repository.UserRepository;
 @Service
 public class ArticleService {
 
+    private static final String FUTURE_PURCHASE_DATE_MESSAGE = "La fecha de compra no puede ser posterior a hoy";
+
     private final ArticleRepository articleRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
@@ -132,6 +134,8 @@ public class ArticleService {
         LocalDate until = article.getAvailableUntil();
         if (from != null && until != null && from.isAfter(until))
             throw new RuntimeException("La fecha de inicio de disponibilidad debe ser posterior o igual a la fecha de finalización");
+
+        validatePurchaseDate(article.getPurchaseDate());
 
         User owner = article.getOwner();
         if (owner == null || owner.getId() == null)
@@ -237,6 +241,12 @@ public class ArticleService {
             return false;
         }
         return l.equals(r);
+    }
+
+    private void validatePurchaseDate(LocalDate purchaseDate) {
+        if (purchaseDate != null && purchaseDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException(FUTURE_PURCHASE_DATE_MESSAGE);
+        }
     }
 
     public void deleteById(Long id, Long ownerId) {
@@ -683,10 +693,12 @@ public class ArticleService {
         if (from != null && until != null && from.isAfter(until))
             throw new RuntimeException("La fecha de inicio de disponibilidad debe ser posterior o igual a la fecha de finalización");
 
-        if (updateData.getPurchaseDate() != null) 
+        if (updateData.getPurchaseDate() != null) {
+            validatePurchaseDate(updateData.getPurchaseDate());
             article.setPurchaseDate(updateData.getPurchaseDate());
+        }
 
-        if (updateData.getCondition() != null) 
+        if (updateData.getCondition() != null)
             article.setCondition(updateData.getCondition());
             
         if (updateData.getImageUrl() != null) 

--- a/backend/src/test/java/com/example/demo/article/ArticleServiceTest.java
+++ b/backend/src/test/java/com/example/demo/article/ArticleServiceTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ArticleServiceTest {
 
+    private static final String FUTURE_PURCHASE_DATE_MESSAGE = "La fecha de compra no puede ser posterior a hoy";
+
     @Mock private ArticleRepository articleRepository;
     @Mock private UserRepository userRepository;
     @Mock private CategoryRepository categoryRepository;
@@ -283,6 +285,26 @@ class ArticleServiceTest {
     }
 
     @Test
+    void save_purchaseDateInFuture_throws() {
+        article.setPurchaseDate(LocalDate.now().plusDays(1));
+        assertThatThrownBy(() -> articleService.save(article))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(FUTURE_PURCHASE_DATE_MESSAGE);
+        verify(articleRepository, never()).save(any());
+    }
+
+    @Test
+    void save_purchaseDateToday_succeeds() {
+        LocalDate today = LocalDate.now();
+        article.setPurchaseDate(today);
+        when(articleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Article result = articleService.save(article);
+
+        assertThat(result.getPurchaseDate()).isEqualTo(today);
+    }
+
+    @Test
     void save_availableFromEqualsUntil_succeeds() {
         LocalDate today = LocalDate.now();
         article.setAvailableFrom(today);
@@ -487,6 +509,19 @@ class ArticleServiceTest {
         assertThatThrownBy(() -> articleService.update(1L, 1L, updateData))
                 .isInstanceOf(RuntimeException.class)
         .hasMessage("La fecha de inicio de disponibilidad debe ser posterior o igual a la fecha de finalización");
+    }
+
+    @Test
+    void update_purchaseDateInFuture_throws() {
+        when(articleRepository.findById(1L)).thenReturn(Optional.of(article));
+
+        Article updateData = new Article();
+        updateData.setPurchaseDate(LocalDate.now().plusDays(1));
+
+        assertThatThrownBy(() -> articleService.update(1L, 1L, updateData))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(FUTURE_PURCHASE_DATE_MESSAGE);
+        verify(articleRepository, never()).save(any());
     }
 
     @Test

--- a/mobile/__tests__/articles/purchaseDateValidation.test.ts
+++ b/mobile/__tests__/articles/purchaseDateValidation.test.ts
@@ -1,0 +1,31 @@
+import {
+  getPurchaseDateValidationError,
+  isFutureIsoDate,
+  PURCHASE_DATE_FUTURE_ERROR,
+  PURCHASE_DATE_INVALID_ERROR,
+} from '../../src/utils/articlePurchaseDate';
+
+describe('purchase date validation', () => {
+  const today = new Date(2026, 4, 6, 15, 30);
+
+  it('permite omitir la fecha de compra', () => {
+    expect(getPurchaseDateValidationError('', today)).toBeNull();
+    expect(getPurchaseDateValidationError('   ', today)).toBeNull();
+  });
+
+  it('permite fechas de compra pasadas o del día actual', () => {
+    expect(getPurchaseDateValidationError('2026-05-05', today)).toBeNull();
+    expect(getPurchaseDateValidationError('2026-05-06', today)).toBeNull();
+  });
+
+  it('rechaza fechas de compra futuras', () => {
+    expect(isFutureIsoDate('2026-05-07', today)).toBe(true);
+    expect(getPurchaseDateValidationError('2026-05-07', today)).toBe(PURCHASE_DATE_FUTURE_ERROR);
+  });
+
+  it('mantiene el error existente para fechas ISO inválidas', () => {
+    expect(getPurchaseDateValidationError('2026-02-30', today)).toBe(PURCHASE_DATE_INVALID_ERROR);
+    expect(getPurchaseDateValidationError('2026-05-06-extra', today)).toBe(PURCHASE_DATE_INVALID_ERROR);
+    expect(getPurchaseDateValidationError('2026-5-6', today)).toBe(PURCHASE_DATE_INVALID_ERROR);
+  });
+});

--- a/mobile/src/screens/profile/EditArticleScreen.tsx
+++ b/mobile/src/screens/profile/EditArticleScreen.tsx
@@ -18,6 +18,7 @@ import { es, registerTranslation } from 'react-native-paper-dates';
 import { useLocationPicker } from '../../hooks/useLocationPicker';
 import { SelectPicker } from '../../components/SelectPicker';
 import { useNotification } from '../../components/NotificationContext';
+import { getPurchaseDateValidationError } from '../../utils/articlePurchaseDate';
 
 const MAX_TITLE_LENGTH = 255;
 const MAX_TOTAL_UNITS = 2147483647; 
@@ -84,15 +85,6 @@ const isoToDate = (iso: string | null | undefined): Date | undefined => {
   if (!iso) return undefined;
   const [y, m, d] = iso.split('-').map(Number);
   return new Date(y, m - 1, d);
-};
-
-const isValidIsoDate = (iso: string): boolean => {
-  if (!iso) return true;
-  const [y, m, d] = iso.split('-').map(Number);
-  if (m < 1 || m > 12) return false;
-  if (d < 1 || d > 31) return false;
-  const date = new Date(y, m - 1, d);
-  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
 };
 
 const hasAtMostTwoDecimals = (value: string): boolean =>
@@ -228,8 +220,10 @@ const EditArticleScreen: React.FC = () => {
     if (!availableUntil) newErrors.availableUntil = 'Selecciona la fecha de fin';
     if (availableFrom && availableUntil && availableFrom >= availableUntil)
       newErrors.availableUntil = 'Debe ser posterior a la fecha de inicio';
-    if (purchaseDate && !isValidIsoDate(purchaseDate))
-      newErrors.purchaseDate = 'Fecha de compra no válida';
+    const purchaseDateError = getPurchaseDateValidationError(purchaseDate);
+    if (purchaseDateError) {
+      newErrors.purchaseDate = purchaseDateError;
+    }
     if (!totalUnits || isNaN(Number(totalUnits)) || Number(totalUnits) < 1 || !Number.isInteger(Number(totalUnits))) {
       newErrors.totalUnits = 'Introduce un número de unidades válido (mínimo 1)';
     }
@@ -649,8 +643,14 @@ const EditArticleScreen: React.FC = () => {
                 onConfirm={(params: { date?: Date }) => {
                   setShowPurchaseDatePicker(false);
                   if (params.date) {
+                    const nextPurchaseDate = toIso(params.date);
+                    const purchaseDateError = getPurchaseDateValidationError(nextPurchaseDate);
+                    if (purchaseDateError) {
+                      setErrors((prev) => ({ ...prev, purchaseDate: purchaseDateError }));
+                      return;
+                    }
                     setPurchaseDateObj(params.date);
-                    setPurchaseDate(toIso(params.date));
+                    setPurchaseDate(nextPurchaseDate);
                     clearError('purchaseDate');
                   }
                 }}

--- a/mobile/src/screens/profile/UploadArticleScreen.tsx
+++ b/mobile/src/screens/profile/UploadArticleScreen.tsx
@@ -19,6 +19,7 @@ import { es, registerTranslation } from 'react-native-paper-dates';
 import { useLocationPicker } from '../../hooks/useLocationPicker';
 import { SelectPicker } from '../../components/SelectPicker';
 import { useNotification } from '../../components/NotificationContext';
+import { getPurchaseDateValidationError } from '../../utils/articlePurchaseDate';
 
 const MAX_TITLE_LENGTH = 255;
 const MAX_TOTAL_UNITS = 2147483647; 
@@ -83,15 +84,6 @@ const toDisplay = (iso: string): string => {
   if (!iso) return '';
   const [y, m, d] = iso.split('-');
   return `${d}/${m}/${y}`;
-};
-
-const isValidIsoDate = (iso: string): boolean => {
-  if (!iso) return true;
-  const [y, m, d] = iso.split('-').map(Number);
-  if (m < 1 || m > 12) return false;
-  if (d < 1 || d > 31) return false;
-  const date = new Date(y, m - 1, d);
-  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
 };
 
 const hasAtMostTwoDecimals = (value: string): boolean =>
@@ -336,8 +328,10 @@ const UploadArticleScreen: React.FC = () => {
     if (!availableUntil) newErrors.availableUntil = 'Selecciona la fecha de fin';
     if (availableFrom && availableUntil && availableFrom >= availableUntil)
       newErrors.availableUntil = 'Debe ser posterior a la fecha de inicio';
-    if (purchaseDate && !isValidIsoDate(purchaseDate))
-      newErrors.purchaseDate = 'Fecha de compra no válida';
+    const purchaseDateError = getPurchaseDateValidationError(purchaseDate);
+    if (purchaseDateError) {
+      newErrors.purchaseDate = purchaseDateError;
+    }
 
     if (!totalUnits || isNaN(Number(totalUnits)) || Number(totalUnits) < 1 || !Number.isInteger(Number(totalUnits))) {
       newErrors.totalUnits = 'Introduce un número de unidades válido (mínimo 1)';
@@ -770,8 +764,14 @@ const UploadArticleScreen: React.FC = () => {
                 onConfirm={(params: { date?: Date }) => {
                   setShowPurchaseDatePicker(false);
                   if (params.date) {
+                    const nextPurchaseDate = toIso(params.date);
+                    const purchaseDateError = getPurchaseDateValidationError(nextPurchaseDate);
+                    if (purchaseDateError) {
+                      setErrors((prev) => ({ ...prev, purchaseDate: purchaseDateError }));
+                      return;
+                    }
                     setPurchaseDateObj(params.date);
-                    setPurchaseDate(toIso(params.date));
+                    setPurchaseDate(nextPurchaseDate);
                     clearError('purchaseDate');
                   }
                 }}

--- a/mobile/src/utils/articlePurchaseDate.ts
+++ b/mobile/src/utils/articlePurchaseDate.ts
@@ -1,0 +1,48 @@
+export const PURCHASE_DATE_FUTURE_ERROR = 'La fecha de compra no puede ser posterior a hoy';
+export const PURCHASE_DATE_INVALID_ERROR = 'Fecha de compra no válida';
+
+export const isValidIsoDate = (iso: string): boolean => {
+  if (!iso) {
+    return true;
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    return false;
+  }
+  const parts = iso.split('-');
+  const [y, m, d] = parts.map((part) => Number(part));
+  if (m < 1 || m > 12) {
+    return false;
+  }
+  if (d < 1 || d > 31) {
+    return false;
+  }
+  const date = new Date(y, m - 1, d);
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+};
+
+export const isFutureIsoDate = (iso: string, today = new Date()): boolean => {
+  if (!isValidIsoDate(iso)) {
+    return false;
+  }
+  const [y, m, d] = iso.split('-').map((part) => Number(part));
+  const selectedDate = new Date(y, m - 1, d);
+  const currentDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  return selectedDate > currentDate;
+};
+
+export const getPurchaseDateValidationError = (
+  purchaseDate: string,
+  today = new Date(),
+): string | null => {
+  const normalizedPurchaseDate = purchaseDate.trim();
+  if (!normalizedPurchaseDate) {
+    return null;
+  }
+  if (!isValidIsoDate(normalizedPurchaseDate)) {
+    return PURCHASE_DATE_INVALID_ERROR;
+  }
+  if (isFutureIsoDate(normalizedPurchaseDate, today)) {
+    return PURCHASE_DATE_FUTURE_ERROR;
+  }
+  return null;
+};


### PR DESCRIPTION
Corrige la validación de la fecha de compra para que no se puedan crear ni editar artículos con una fecha posterior al día actual.

Cambios

- Añadida una validación frontend reutilizable para purchaseDate.
- Aplicada la validación en las pantallas de subir y editar artículo.
- Añadida validación en backend en ArticleService como capa de seguridad adicional.
- Se muestra un error claro cuando la fecha de compra está en el futuro.

Testing

- Validación frontend de fechas vacías, válidas, futuras e inválidas.
- Rechazo en backend al crear artículos con fecha de compra futura.
- Rechazo en backend al editar artículos con fecha de compra futura.
- Creación permitida cuando la fecha de compra es el día actual.