### PR TITLE
fix: add custom pattern validator to all email fields

### DIFF
--- a/backend/src/main/java/com/example/demo/dto/AdminUserRequest.java
+++ b/backend/src/main/java/com/example/demo/dto/AdminUserRequest.java
@@ -11,6 +11,7 @@ public class AdminUserRequest {
 
     @NotBlank(message = "El email es obligatorio")
     @Email(message = "El formato del email no es válido")
+    @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "El formato del email no es válido")
     @Size(max = 255, message = "El email no puede tener más de 255 caracteres")
     private String email;
     

--- a/backend/src/main/java/com/example/demo/dto/LoginRequest.java
+++ b/backend/src/main/java/com/example/demo/dto/LoginRequest.java
@@ -2,10 +2,12 @@ package com.example.demo.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public class LoginRequest {
     @NotBlank(message = "Email is required")
     @Email(message = "Email should be valid")
+    @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "Email should be valid")
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/backend/src/main/java/com/example/demo/dto/PilotUserRequest.java
+++ b/backend/src/main/java/com/example/demo/dto/PilotUserRequest.java
@@ -2,8 +2,13 @@ package com.example.demo.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record PilotUserRequest(
-    @NotBlank @Email(message = "El email no tiene un formato válido") String email,
+    @NotBlank 
+    @Email(message = "El email no tiene un formato válido") 
+    @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "El email no tiene un formato válido")
+    String email,
+
     boolean active
 ) {}

--- a/backend/src/main/java/com/example/demo/dto/PromoCodeRequest.java
+++ b/backend/src/main/java/com/example/demo/dto/PromoCodeRequest.java
@@ -22,5 +22,9 @@ public record PromoCodeRequest(
 
     boolean pilotUserOnly,
 
-    List<@Email(message = "El email '${validatedValue}' no tiene un formato válido") String> pilotEmails
+    List<
+        @Email(message = "El email '${validatedValue}' no tiene un formato válido")
+        @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "El email '${validatedValue}' no tiene un formato válido")
+        String
+    > pilotEmails
 ) {}

--- a/backend/src/main/java/com/example/demo/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/example/demo/dto/RegisterRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Size;
 public class RegisterRequest {
     @NotBlank(message = "Email is required")
     @Email(message = "Email should be valid")
+    @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "Email should be valid")
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/backend/src/main/java/com/example/demo/model/User.java
+++ b/backend/src/main/java/com/example/demo/model/User.java
@@ -15,6 +15,7 @@ public class User {
 
     @Column(nullable = false, unique = true)
     @Email
+    @Pattern(regexp = "^[^@]+@[^@]+\\.[^@]+$", message = "Email should be valid")
     private String email;
 
     @Column(nullable = false)


### PR DESCRIPTION
Se podían introducir emails del tipo email@examplecom (sin punto). Se ha añadido un pattern en todos los lugares en los que hacía falta