### PR TITLE
fix: default status for new articles

### DIFF
--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -123,6 +123,10 @@ public class ArticleService {
             }
         }
 
+        if (article.getId() == null) {
+            article.setStatus(ArticleStatus.AVAILABLE);
+        }
+
         if (article.getTotalUnits() == null || article.getTotalUnits() < 1)
             article.setTotalUnits(1);
 


### PR DESCRIPTION
El backend asegura un estado por defecto a la hora de crear un artículo, evitando así que se pueda inyectar desde el frontend un estado no válido.