### PR TITLE
fix: category cannot be DRAFT

### DIFF
--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -672,9 +672,12 @@ public class ArticleService {
         }
 
         Category resolvedCategory = article.getCategory();
-        if (updateData.getCategory() != null && updateData.getCategory().getId() != null && updateData.getCategory().getStatus() != CategoryStatus.DRAFT) {
+        if (updateData.getCategory() != null && updateData.getCategory().getId() != null) {
             resolvedCategory = categoryRepository.findById(updateData.getCategory().getId())
                 .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
+            if (resolvedCategory.getStatus() == CategoryStatus.DRAFT) {
+                throw new RuntimeException("No se puede asignar una categoría en estado Borrador a un artículo");
+            }
             article.setCategory(resolvedCategory);
         }
         if (resolvedCategory != null && article.getPricePerMonth() != null) {

--- a/backend/src/main/java/com/example/demo/service/ArticleService.java
+++ b/backend/src/main/java/com/example/demo/service/ArticleService.java
@@ -22,6 +22,7 @@ import com.example.demo.model.Article;
 import com.example.demo.model.ArticleFilter;
 import com.example.demo.model.ArticleStatus;
 import com.example.demo.model.Category;
+import com.example.demo.model.CategoryStatus;
 import com.example.demo.model.ItemMemento;
 import com.example.demo.model.Kit;
 import com.example.demo.model.KitStatus;
@@ -671,7 +672,7 @@ public class ArticleService {
         }
 
         Category resolvedCategory = article.getCategory();
-        if (updateData.getCategory() != null && updateData.getCategory().getId() != null) {
+        if (updateData.getCategory() != null && updateData.getCategory().getId() != null && updateData.getCategory().getStatus() != CategoryStatus.DRAFT) {
             resolvedCategory = categoryRepository.findById(updateData.getCategory().getId())
                 .orElseThrow(() -> new RuntimeException("Categoría no encontrada"));
             article.setCategory(resolvedCategory);


### PR DESCRIPTION
A la hora de actualizar un artículo, el backend comprueba que la categoría asignada no tenga como estado 'DRAFT'.